### PR TITLE
feat: 温度 / 事件告警（webhook · 命令 · 日志）

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ smctl sensors --watch            # live temperatures, fan RPM, package power
 | `smctl fan set 2500 [--fan N]` | Manual fan target |
 | `smctl fan profile quiet\|full\|auto\|<custom>` | Declarative fan curves (TOML), hysteresis + slew-rate limited |
 | `smctl power status [--watch] [--json]` | Thermal pressure, CPU throttling (% speed limit), package + input power |
+| `smctl alert status\|test <name>` | Temperature/event alerts → webhook, command, or log (configured in TOML) |
 | `smctl daemon install\|uninstall\|status\|ping` | Manage the privileged helper |
 
 Policies live in `/etc/smctl/config.toml` — declarative, diffable, dotfiles-friendly.
@@ -85,14 +86,53 @@ Controlling fans and charging from userspace demands paranoia. smctl treats thes
 
 ## Privacy
 
-The daemon makes exactly one kind of outbound network request: a once-a-day check of the GitHub releases API to learn the latest version, which the CLI surfaces as an upgrade hint. Nothing else leaves your machine — no telemetry, no analytics. Turn it off with:
+The daemon makes outbound network requests in exactly two cases, both under your control:
+
+1. **Update check** — a once-a-day check of the GitHub releases API to learn the latest version, surfaced by the CLI as an upgrade hint. On by default; turn it off with `[update] check = false`.
+2. **Alert webhooks** — only the webhook URLs *you* configure in `[[alert]]` rules. No alerts configured (the default) means no such requests.
+
+There is no telemetry and no analytics. The CLI itself never makes network requests — all outbound traffic originates in the daemon, from the two opt-in/opt-out cases above. To go fully offline, set:
 
 ```toml
 [update]
 check = false
 ```
 
-in `/etc/smctl/config.toml` (then `sudo smctl daemon restart`). The CLI itself never makes network requests.
+in `/etc/smctl/config.toml` (then `sudo smctl daemon restart`) and configure no webhook alerts.
+
+## Alerts
+
+The daemon already watches every temperature sensor once a second for the thermal safety guard. Alert rules hang off that same loop: when a condition holds, the daemon runs an action — a shell command, an HTTP webhook, or a log line. Useful for a headless Mac mini wired into Prometheus/Gotify/etc.
+
+Rules are declarative TOML in `/etc/smctl/config.toml`:
+
+```toml
+[[alert]]
+name = "cpu-hot"
+on = "temp"            # temp | guard | write-error
+sensor = "Tp09"        # a sensor key, or "any" for the hottest
+above = 85             # °C
+for = 30               # must hold this many seconds before firing (debounce)
+cooldown = 300         # silence re-firing for this many seconds
+resolve = true         # also fire once when the condition clears
+action = "webhook"     # webhook | exec | log
+url = "http://gotify.lan/message?token=..."
+
+[[alert]]
+name = "guard-tripped"
+on = "guard"           # the thermal safety guard forced fans back to auto
+action = "exec"
+command = ["/usr/local/bin/notify.sh", "{name}", "{reason}"]
+```
+
+`exec` commands receive the event as both substituted argv placeholders (`{name}` `{kind}` `{trigger}` `{reason}` `{value}`) and `SMCTL_ALERT_*` environment variables. Inspect and verify rules with:
+
+```console
+$ smctl alert status          # per-rule state + recent events
+$ smctl alert test cpu-hot    # fire the action now, to check your webhook/script
+```
+
+> **Security:** `exec` actions run as **root** (the daemon is root). The trust boundary is whoever can edit the root-owned `/etc/smctl/config.toml` — the same boundary as every other policy. Commands run via argv arrays only (no shell), so there is no command-injection surface, but treat write access to the config as equivalent to root.
 
 ## Supported hardware
 

--- a/Sources/PolicyEngine/AlertEngine.swift
+++ b/Sources/PolicyEngine/AlertEngine.swift
@@ -1,0 +1,272 @@
+import Foundation
+
+/// What an alert rule watches. Kept deliberately small for the first cut:
+/// temperature thresholds, the fan safety guard tripping, and SMC write
+/// failures — all sourced from data the daemon already collects every tick.
+public enum AlertTriggerKind: String, Codable, Equatable, Sendable {
+    /// A temperature sensor sustained above a threshold.
+    case temp
+    /// The fan thermal safety guard forced fans back to auto.
+    case guardTripped = "guard"
+    /// An SMC write failed verification (data-correctness signal).
+    case writeError = "write-error"
+}
+
+public struct AlertTrigger: Equatable, Sendable {
+    public var kind: AlertTriggerKind
+    /// For `.temp`: the sensor key to watch, or "any" to match the hottest sensor.
+    public var sensor: String?
+    /// For `.temp`: the ceiling in Celsius; firing requires a reading strictly above it.
+    public var above: Double?
+
+    public init(kind: AlertTriggerKind, sensor: String? = nil, above: Double? = nil) {
+        self.kind = kind
+        self.sensor = sensor
+        self.above = above
+    }
+}
+
+public struct AlertRule: Equatable, Sendable {
+    public var name: String
+    public var trigger: AlertTrigger
+    /// Sustained-duration debounce: the condition must hold this long before firing.
+    public var forSeconds: Double
+    /// After firing, suppress re-firing for this long.
+    public var cooldownSeconds: Double
+    /// Emit a `.resolved` event when the condition clears after firing.
+    public var resolve: Bool
+
+    public init(
+        name: String,
+        trigger: AlertTrigger,
+        forSeconds: Double = 0,
+        cooldownSeconds: Double = 300,
+        resolve: Bool = false
+    ) {
+        self.name = name
+        self.trigger = trigger
+        self.forSeconds = max(0, forSeconds)
+        self.cooldownSeconds = max(0, cooldownSeconds)
+        self.resolve = resolve
+    }
+}
+
+/// The per-tick metric snapshot the engine evaluates rules against. The daemon
+/// already has all of this in hand inside its 1 Hz fan loop.
+public struct AlertConditionInput: Equatable, Sendable {
+    public var samples: [FanTemperatureSample]
+    public var guardTripped: Bool
+    public var guardReason: String?
+    /// Non-nil when the most recent SMC write failed (verification/IO error).
+    public var writeError: String?
+
+    public init(
+        samples: [FanTemperatureSample] = [],
+        guardTripped: Bool = false,
+        guardReason: String? = nil,
+        writeError: String? = nil
+    ) {
+        self.samples = samples
+        self.guardTripped = guardTripped
+        self.guardReason = guardReason
+        self.writeError = writeError
+    }
+}
+
+public enum AlertEventKind: String, Codable, Equatable, Sendable {
+    case fired
+    case resolved
+}
+
+public struct AlertEvent: Equatable, Sendable {
+    public var ruleName: String
+    public var kind: AlertEventKind
+    public var triggerKind: AlertTriggerKind
+    public var reason: String
+    /// The numeric reading that crossed the threshold, when applicable (Celsius).
+    public var value: Double?
+    public var timestamp: Date
+
+    public init(
+        ruleName: String,
+        kind: AlertEventKind,
+        triggerKind: AlertTriggerKind,
+        reason: String,
+        value: Double?,
+        timestamp: Date
+    ) {
+        self.ruleName = ruleName
+        self.kind = kind
+        self.triggerKind = triggerKind
+        self.reason = reason
+        self.value = value
+        self.timestamp = timestamp
+    }
+}
+
+/// Observable per-rule state, surfaced to the CLI via `smctl alert status`.
+public enum AlertRuleStatus: String, Codable, Equatable, Sendable {
+    /// Condition not met; ready to fire.
+    case armed
+    /// Condition met but `for` debounce not yet elapsed.
+    case pending
+    /// Fired and currently within its cooldown window.
+    case cooling
+    /// Fired, condition still active, cooldown elapsed (will re-fire next match).
+    case firing
+}
+
+public struct AlertRuleState: Equatable, Sendable {
+    public var name: String
+    public var status: AlertRuleStatus
+    public var lastFired: Date?
+    public var lastValue: Double?
+
+    public init(name: String, status: AlertRuleStatus, lastFired: Date? = nil, lastValue: Double? = nil) {
+        self.name = name
+        self.status = status
+        self.lastFired = lastFired
+        self.lastValue = lastValue
+    }
+}
+
+/// Edge-triggered alert state machine. One runtime per rule name; the machine is
+/// stateful (debounce timers, cooldown, fired latch) and must be evaluated every
+/// tick so it can both fire and resolve. Pure: no I/O, `now` injected for tests.
+///
+/// Per-rule lifecycle:
+///   armed → (condition true) pending(remember start)
+///         → (held ≥ for) FIRED, cooling(cooldown)
+///         → (condition false) [resolve? RESOLVED] → armed
+public struct AlertEngine: Equatable, Sendable {
+    private struct Runtime: Equatable {
+        var pendingSince: Date?
+        var fired: Bool = false
+        var cooldownUntil: Date?
+        var lastFired: Date?
+        var lastValue: Double?
+    }
+
+    private var runtimes: [String: Runtime] = [:]
+
+    public init() {}
+
+    public mutating func evaluate(rules: [AlertRule], input: AlertConditionInput, now: Date) -> [AlertEvent] {
+        var events: [AlertEvent] = []
+        var liveNames = Set<String>()
+
+        for rule in rules {
+            liveNames.insert(rule.name)
+            var runtime = runtimes[rule.name] ?? Runtime()
+            let match = condition(rule.trigger, input: input)
+
+            if match.active {
+                runtime.lastValue = match.value
+                if runtime.pendingSince == nil {
+                    runtime.pendingSince = now
+                }
+                let heldLongEnough = now.timeIntervalSince(runtime.pendingSince ?? now) >= rule.forSeconds
+                let cooledDown = runtime.cooldownUntil.map { now >= $0 } ?? true
+                if heldLongEnough, cooledDown {
+                    events.append(AlertEvent(
+                        ruleName: rule.name,
+                        kind: .fired,
+                        triggerKind: rule.trigger.kind,
+                        reason: match.reason,
+                        value: match.value,
+                        timestamp: now
+                    ))
+                    runtime.fired = true
+                    runtime.lastFired = now
+                    runtime.cooldownUntil = now.addingTimeInterval(rule.cooldownSeconds)
+                }
+            } else {
+                if runtime.fired, rule.resolve {
+                    events.append(AlertEvent(
+                        ruleName: rule.name,
+                        kind: .resolved,
+                        triggerKind: rule.trigger.kind,
+                        reason: "Condition cleared",
+                        value: match.value,
+                        timestamp: now
+                    ))
+                }
+                runtime.fired = false
+                runtime.pendingSince = nil
+            }
+
+            runtimes[rule.name] = runtime
+        }
+
+        // Drop runtimes for rules removed from config so state never leaks.
+        runtimes = runtimes.filter { liveNames.contains($0.key) }
+        return events
+    }
+
+    public func states(for rules: [AlertRule], now: Date) -> [AlertRuleState] {
+        rules.map { rule in
+            let runtime = runtimes[rule.name] ?? Runtime()
+            let status: AlertRuleStatus
+            if runtime.fired {
+                let cooling = runtime.cooldownUntil.map { now < $0 } ?? false
+                status = cooling ? .cooling : .firing
+            } else if runtime.pendingSince != nil {
+                status = .pending
+            } else {
+                status = .armed
+            }
+            return AlertRuleState(
+                name: rule.name,
+                status: status,
+                lastFired: runtime.lastFired,
+                lastValue: runtime.lastValue
+            )
+        }
+    }
+
+    private struct Condition {
+        var active: Bool
+        var reason: String
+        var value: Double?
+    }
+
+    private func condition(_ trigger: AlertTrigger, input: AlertConditionInput) -> Condition {
+        switch trigger.kind {
+        case .temp:
+            guard let above = trigger.above else {
+                return Condition(active: false, reason: "No threshold configured", value: nil)
+            }
+            let matching = input.samples.filter { sample in
+                guard let sensor = trigger.sensor, sensor.lowercased() != "any" else { return true }
+                return sample.sensor == sensor
+            }
+            // Fire on the hottest matching sensor that exceeds the ceiling.
+            if let hottest = matching.filter({ $0.celsius > above }).max(by: { $0.celsius < $1.celsius }) {
+                return Condition(
+                    active: true,
+                    reason: "\(hottest.sensor) at \(format(hottest.celsius))C exceeds \(format(above))C",
+                    value: hottest.celsius
+                )
+            }
+            // Report the current hottest matching reading for `status`/resolve context.
+            let peak = matching.max(by: { $0.celsius < $1.celsius })?.celsius
+            return Condition(active: false, reason: "Below threshold", value: peak)
+        case .guardTripped:
+            return Condition(
+                active: input.guardTripped,
+                reason: input.guardReason ?? "Fan safety guard tripped",
+                value: nil
+            )
+        case .writeError:
+            return Condition(
+                active: input.writeError != nil,
+                reason: input.writeError ?? "SMC write failed",
+                value: nil
+            )
+        }
+    }
+
+    private func format(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+}

--- a/Sources/SMCtlDaemonCore/Alerting.swift
+++ b/Sources/SMCtlDaemonCore/Alerting.swift
@@ -1,0 +1,242 @@
+import Foundation
+import OSLog
+import PolicyEngine
+import SMCtlProtocol
+
+private let alertLogger = Logger(subsystem: "one.leaper.smctl", category: "alert")
+
+/// TOML mapping for one `[[alert]]` table. Mirrors `FanCurveConfig`'s relationship
+/// to `FanCurve`: this is the on-disk shape, `rule` is the engine's view.
+///
+/// Defensive decoding throughout: a hand-edited or older config with missing keys
+/// must never blow up `loadConfig` (which would silently reset the whole file).
+struct AlertConfig: Codable, Equatable, Sendable {
+    var name: String
+    var on: String
+    var sensor: String?
+    var above: Double?
+    var forSeconds: Double?
+    var cooldown: Double?
+    var resolve: Bool?
+    var action: String?
+    var url: String?
+    var command: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case name, on, sensor, above
+        case forSeconds = "for"
+        case cooldown, resolve, action, url, command
+    }
+
+    init(
+        name: String,
+        on: String,
+        sensor: String? = nil,
+        above: Double? = nil,
+        forSeconds: Double? = nil,
+        cooldown: Double? = nil,
+        resolve: Bool? = nil,
+        action: String? = nil,
+        url: String? = nil,
+        command: [String]? = nil
+    ) {
+        self.name = name
+        self.on = on
+        self.sensor = sensor
+        self.above = above
+        self.forSeconds = forSeconds
+        self.cooldown = cooldown
+        self.resolve = resolve
+        self.action = action
+        self.url = url
+        self.command = command
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        on = try container.decodeIfPresent(String.self, forKey: .on) ?? ""
+        sensor = try container.decodeIfPresent(String.self, forKey: .sensor)
+        above = try container.decodeIfPresent(Double.self, forKey: .above)
+        forSeconds = try container.decodeIfPresent(Double.self, forKey: .forSeconds)
+        cooldown = try container.decodeIfPresent(Double.self, forKey: .cooldown)
+        resolve = try container.decodeIfPresent(Bool.self, forKey: .resolve)
+        action = try container.decodeIfPresent(String.self, forKey: .action)
+        url = try container.decodeIfPresent(String.self, forKey: .url)
+        command = try container.decodeIfPresent([String].self, forKey: .command)
+    }
+
+    /// The engine rule, or nil when the config is malformed (unknown trigger kind
+    /// or empty name) — invalid rules are dropped, never crash the daemon.
+    var rule: AlertRule? {
+        guard !name.isEmpty, let kind = AlertTriggerKind(rawValue: on) else { return nil }
+        return AlertRule(
+            name: name,
+            trigger: AlertTrigger(kind: kind, sensor: sensor, above: above),
+            forSeconds: forSeconds ?? 0,
+            cooldownSeconds: cooldown ?? 300,
+            resolve: resolve ?? false
+        )
+    }
+
+    var resolvedAction: AlertAction {
+        switch action {
+        case "webhook":
+            if let url, !url.isEmpty { return .webhook(url) }
+            return .log
+        case "exec":
+            if let command, !command.isEmpty { return .exec(command) }
+            return .log
+        default:
+            return .log
+        }
+    }
+}
+
+enum AlertAction: Equatable, Sendable {
+    case webhook(String)
+    case exec([String])
+    case log
+}
+
+/// Executes alert actions off the daemon's state queue. Three hard rules, because
+/// an alert action must NEVER compromise the daemon's real job:
+///   1. Isolation — runs on its own queue; never blocks the 1 Hz fan loop.
+///   2. Bounded — every exec/webhook has a timeout; a concurrency cap prevents a
+///      stuck endpoint from piling up processes.
+///   3. Silent failure — a failed action is logged, never propagated.
+///
+/// Security note: exec runs as root (the daemon is root). The trust boundary is
+/// "whoever can edit the root-owned /etc/smctl/config.toml" — identical to
+/// `allow_below_minimum`. Commands run via argv arrays only; no shell, no string
+/// interpolation into a shell, so there is no command-injection surface.
+final class AlertActionRunner: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "one.leaper.smctl.alert.actions", attributes: .concurrent)
+    private let slots: DispatchSemaphore
+    private let execTimeout: TimeInterval
+    private let webhookTimeout: TimeInterval
+
+    init(maxConcurrent: Int = 4, execTimeout: TimeInterval = 10, webhookTimeout: TimeInterval = 15) {
+        self.slots = DispatchSemaphore(value: max(1, maxConcurrent))
+        self.execTimeout = execTimeout
+        self.webhookTimeout = webhookTimeout
+    }
+
+    func run(event: AlertEvent, action: AlertAction) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            // Non-blocking admission: if all slots are busy, drop rather than queue
+            // unboundedly. A stuck webhook must not let events accumulate forever.
+            guard self.slots.wait(timeout: .now()) == .success else {
+                alertLogger.error("Alert '\(event.ruleName, privacy: .public)' action dropped: all action slots busy")
+                return
+            }
+            defer { self.slots.signal() }
+            switch action {
+            case .log:
+                self.logAction(event)
+            case .webhook(let url):
+                self.runWebhook(url: url, event: event)
+            case .exec(let command):
+                self.runExec(command: command, event: event)
+            }
+        }
+    }
+
+    private func logAction(_ event: AlertEvent) {
+        alertLogger.notice("Alert \(event.kind.rawValue, privacy: .public) '\(event.ruleName, privacy: .public)': \(event.reason, privacy: .public)")
+    }
+
+    private func runWebhook(url urlString: String, event: AlertEvent) {
+        guard let url = URL(string: urlString) else {
+            alertLogger.error("Alert '\(event.ruleName, privacy: .public)' webhook skipped: invalid URL")
+            return
+        }
+        var request = URLRequest(url: url, timeoutInterval: webhookTimeout)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("smctl-alert/\(SMCtlProtocolInfo.version)", forHTTPHeaderField: "User-Agent")
+        request.httpBody = webhookBody(event)
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let task = URLSession.shared.dataTask(with: request) { _, response, error in
+            if let error {
+                alertLogger.error("Alert '\(event.ruleName, privacy: .public)' webhook failed: \(String(describing: error), privacy: .public)")
+            } else if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                alertLogger.error("Alert '\(event.ruleName, privacy: .public)' webhook HTTP \(http.statusCode, privacy: .public)")
+            }
+            semaphore.signal()
+        }
+        task.resume()
+        // Bound the wait so a hung connection still frees its slot.
+        if semaphore.wait(timeout: .now() + webhookTimeout + 2) == .timedOut {
+            task.cancel()
+            alertLogger.error("Alert '\(event.ruleName, privacy: .public)' webhook timed out")
+        }
+    }
+
+    private func webhookBody(_ event: AlertEvent) -> Data? {
+        var payload: [String: Any] = [
+            "rule": event.ruleName,
+            "kind": event.kind.rawValue,
+            "trigger": event.triggerKind.rawValue,
+            "reason": event.reason,
+            "host": ProcessInfo.processInfo.hostName,
+            "timestamp": ISO8601DateFormatter().string(from: event.timestamp)
+        ]
+        if let value = event.value { payload["value"] = value }
+        return try? JSONSerialization.data(withJSONObject: payload)
+    }
+
+    private func runExec(command: [String], event: AlertEvent) {
+        let substituted = command.map { substitute($0, event: event) }
+        guard let executable = substituted.first else { return }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = Array(substituted.dropFirst())
+        // Pass structured fields via the environment too, so scripts can read them
+        // without positional-argument juggling.
+        var environment = ProcessInfo.processInfo.environment
+        environment["SMCTL_ALERT_NAME"] = event.ruleName
+        environment["SMCTL_ALERT_KIND"] = event.kind.rawValue
+        environment["SMCTL_ALERT_TRIGGER"] = event.triggerKind.rawValue
+        environment["SMCTL_ALERT_REASON"] = event.reason
+        if let value = event.value { environment["SMCTL_ALERT_VALUE"] = String(value) }
+        process.environment = environment
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            alertLogger.error("Alert '\(event.ruleName, privacy: .public)' exec failed to launch '\(executable, privacy: .public)': \(String(describing: error), privacy: .public)")
+            return
+        }
+        // Enforce a timeout: kill the process if it overruns.
+        let deadline = DispatchTime.now() + execTimeout
+        let killer = DispatchWorkItem { [weak process] in
+            if process?.isRunning == true {
+                process?.terminate()
+                alertLogger.error("Alert '\(event.ruleName, privacy: .public)' exec timed out; terminated")
+            }
+        }
+        queue.asyncAfter(deadline: deadline, execute: killer)
+        process.waitUntilExit()
+        killer.cancel()
+        if process.terminationStatus != 0 {
+            alertLogger.error("Alert '\(event.ruleName, privacy: .public)' exec exited \(process.terminationStatus, privacy: .public)")
+        }
+    }
+
+    /// Substitutes {name}/{kind}/{trigger}/{reason}/{value} placeholders. Used only
+    /// for argv elements — never assembled into a shell command line.
+    private func substitute(_ template: String, event: AlertEvent) -> String {
+        var result = template
+        result = result.replacingOccurrences(of: "{name}", with: event.ruleName)
+        result = result.replacingOccurrences(of: "{kind}", with: event.kind.rawValue)
+        result = result.replacingOccurrences(of: "{trigger}", with: event.triggerKind.rawValue)
+        result = result.replacingOccurrences(of: "{reason}", with: event.reason)
+        result = result.replacingOccurrences(of: "{value}", with: event.value.map { String($0) } ?? "")
+        return result
+    }
+}

--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -21,17 +21,25 @@ struct DaemonConfig: Codable, Equatable, Sendable {
     var fan: FanConfig
     var safety: SafetyConfig
     var update: UpdateConfig
+    var alerts: [AlertConfig]
 
     init(
         battery: BatteryConfig = BatteryConfig(),
         fan: FanConfig = FanConfig(),
         safety: SafetyConfig = SafetyConfig(),
-        update: UpdateConfig = UpdateConfig()
+        update: UpdateConfig = UpdateConfig(),
+        alerts: [AlertConfig] = []
     ) {
         self.battery = battery
         self.fan = fan
         self.safety = safety
         self.update = update
+        self.alerts = alerts
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case battery, fan, safety, update
+        case alerts = "alert"
     }
 
     init(from decoder: Decoder) throws {
@@ -40,6 +48,7 @@ struct DaemonConfig: Codable, Equatable, Sendable {
         fan = try container.decodeIfPresent(FanConfig.self, forKey: .fan) ?? FanConfig()
         safety = try container.decodeIfPresent(SafetyConfig.self, forKey: .safety) ?? SafetyConfig()
         update = try container.decodeIfPresent(UpdateConfig.self, forKey: .update) ?? UpdateConfig()
+        alerts = try container.decodeIfPresent([AlertConfig].self, forKey: .alerts) ?? []
     }
 }
 
@@ -206,6 +215,11 @@ public final class SmctlDaemon: @unchecked Sendable {
     private var runtimeFanProfile: String?
     // Stateful: carries the safety latch across ticks; ceiling refreshed from config.
     var safetyGuard = FanSafetyGuard()
+    // Stateful: carries per-rule debounce/cooldown across ticks.
+    var alertEngine = AlertEngine()
+    private let alertRunner = AlertActionRunner()
+    private var alertHistory: [AlertEvent] = []
+    private static let alertHistoryLimit = 50
     private var lastEvaluation: Date?
     private var lastError: String?
     private var timer: DispatchSourceTimer?
@@ -266,7 +280,7 @@ public final class SmctlDaemon: @unchecked Sendable {
         let fanSource = DispatchSource.makeTimerSource(queue: queue)
         fanSource.schedule(deadline: .now() + .seconds(1), repeating: .seconds(1))
         fanSource.setEventHandler { [weak self] in
-            self?.evaluateFanSubsystemLocked()
+            self?.tickFanAndAlertsLocked()
         }
         fanSource.resume()
         queue.sync {
@@ -631,12 +645,21 @@ public final class SmctlDaemon: @unchecked Sendable {
         return capped
     }
 
-    func evaluateFanSubsystemLocked() {
+    /// One 1 Hz tick: read temperatures once, drive the fan subsystem, then the
+    /// alert engine. Alerts run even on fanless Macs (where the fan subsystem
+    /// early-returns) so temperature/write-error alerts still work there.
+    func tickFanAndAlertsLocked() {
+        let samples = temperatureSamplesLocked()
+        evaluateFanSubsystemLocked(samples: samples)
+        evaluateAlertsLocked(samples: samples)
+    }
+
+    func evaluateFanSubsystemLocked(samples providedSamples: [FanTemperatureSample]? = nil) {
         guard backend != nil, !capabilities.fans.isEmpty else {
             return
         }
 
-        let samples = temperatureSamplesLocked()
+        let samples = providedSamples ?? temperatureSamplesLocked()
         let profile = currentFanProfileLocked()
         // "Manual policy active" covers direct manual targets, residual Ftst/manual
         // modes, and curve profiles (which drive fans via manual mode every tick).
@@ -677,6 +700,85 @@ public final class SmctlDaemon: @unchecked Sendable {
         } catch {
             lastError = String(describing: error)
             logger.error("Fan policy evaluation failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Evaluate alert rules against the current tick's metrics and dispatch any
+    /// edge-triggered events to the (isolated) action runner. Runs on the state
+    /// queue; the runner does all blocking work off-queue.
+    private func evaluateAlertsLocked(samples: [FanTemperatureSample]) {
+        let rules = config.alerts.compactMap(\.rule)
+        guard !rules.isEmpty else { return }
+        let latched = safetyGuard.isLatched
+        let input = AlertConditionInput(
+            samples: samples,
+            guardTripped: latched,
+            guardReason: latched ? "Fan safety guard latched (overheat or unreadable temperature sensors)" : nil,
+            writeError: lastError
+        )
+        let events = alertEngine.evaluate(rules: rules, input: input, now: Date())
+        guard !events.isEmpty else { return }
+        let actionByName = Dictionary(
+            config.alerts.map { ($0.name, $0.resolvedAction) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for event in events {
+            recordAlertLocked(event)
+            alertRunner.run(event: event, action: actionByName[event.ruleName] ?? .log)
+        }
+    }
+
+    private func recordAlertLocked(_ event: AlertEvent) {
+        alertHistory.append(event)
+        if alertHistory.count > Self.alertHistoryLimit {
+            alertHistory.removeFirst(alertHistory.count - Self.alertHistoryLimit)
+        }
+    }
+
+    func alertStatus() -> AlertStatusDTO {
+        queue.sync {
+            let rules = config.alerts.compactMap(\.rule)
+            let now = Date()
+            let states = alertEngine.states(for: rules, now: now).map { state in
+                AlertRuleStateDTO(
+                    name: state.name,
+                    status: state.status.rawValue,
+                    lastFired: state.lastFired,
+                    lastValue: state.lastValue
+                )
+            }
+            let history = alertHistory.suffix(20).map { event in
+                AlertEventDTO(
+                    ruleName: event.ruleName,
+                    kind: event.kind.rawValue,
+                    trigger: event.triggerKind.rawValue,
+                    reason: event.reason,
+                    value: event.value,
+                    timestamp: event.timestamp
+                )
+            }
+            return AlertStatusDTO(timestamp: now, rules: states, recent: Array(history))
+        }
+    }
+
+    /// Fire one rule's action immediately, bypassing trigger evaluation, so an
+    /// operator can verify a freshly-configured webhook/exec actually works.
+    func testAlert(name: String) throws {
+        try queue.sync {
+            guard let config = config.alerts.first(where: { $0.name == name }) else {
+                throw DaemonError.unsupported("No alert named '\(name)' is configured.")
+            }
+            let trigger = config.rule?.trigger.kind ?? .temp
+            let event = AlertEvent(
+                ruleName: name,
+                kind: .fired,
+                triggerKind: trigger,
+                reason: "Test trigger via 'smctl alert test'",
+                value: nil,
+                timestamp: Date()
+            )
+            recordAlertLocked(event)
+            alertRunner.run(event: event, action: config.resolvedAction)
         }
     }
 
@@ -956,7 +1058,27 @@ public final class SmctlDaemon: @unchecked Sendable {
                 text += "weights = { \(pairs) }\n"
             }
         }
+        // Round-trip alert rules so a battery/fan write never silently drops the
+        // user's alert config (writeConfig rewrites the whole file).
+        for alert in config.alerts {
+            text += formatAlert(alert)
+        }
         try text.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    private static func formatAlert(_ alert: AlertConfig) -> String {
+        var lines = ["", "[[alert]]", "name = \"\(alert.name)\"", "on = \"\(alert.on)\""]
+        if let sensor = alert.sensor { lines.append("sensor = \"\(sensor)\"") }
+        if let above = alert.above { lines.append("above = \(above)") }
+        if let forSeconds = alert.forSeconds { lines.append("for = \(forSeconds)") }
+        if let cooldown = alert.cooldown { lines.append("cooldown = \(cooldown)") }
+        if let resolve = alert.resolve { lines.append("resolve = \(resolve ? "true" : "false")") }
+        if let action = alert.action { lines.append("action = \"\(action)\"") }
+        if let url = alert.url { lines.append("url = \"\(url)\"") }
+        if let command = alert.command {
+            lines.append("command = [\(command.map { "\"\($0)\"" }.joined(separator: ", "))]")
+        }
+        return lines.joined(separator: "\n") + "\n"
     }
 
     private static func formatFanPoint(_ values: [FanPointValue]) -> String {
@@ -1040,6 +1162,17 @@ final class XPCService: NSObject, SMCtlDaemonXPCProtocol {
 
     func getDaemonStatus(withReply reply: @escaping (Data?, String?) -> Void) {
         send(daemon.daemonStatus(), reply)
+    }
+
+    func getAlertStatus(withReply reply: @escaping (Data?, String?) -> Void) {
+        send(daemon.alertStatus(), reply)
+    }
+
+    func testAlert(_ requestData: Data, withReply reply: @escaping (Data?, String?) -> Void) {
+        doWrite(reply) {
+            let request = try SMCtlProtocolCoding.decode(TestAlertRequestDTO.self, from: requestData)
+            try daemon.testAlert(name: request.name)
+        }
     }
 
     func setChargeLimit(_ requestData: Data, withReply reply: @escaping (Data?, String?) -> Void) {

--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -222,6 +222,7 @@ public final class SmctlDaemon: @unchecked Sendable {
     private static let alertHistoryLimit = 50
     private var lastEvaluation: Date?
     private var lastError: String?
+    private var lastWriteError: String?
     private var timer: DispatchSourceTimer?
     private var fanTimer: DispatchSourceTimer?
     private var updateTimer: DispatchSourceTimer?
@@ -409,7 +410,9 @@ public final class SmctlDaemon: @unchecked Sendable {
         try queue.sync {
             try rejectIfSafetyLatchedLocked()
             let target = try normalizedFanRPM(index: index, rpm: rpm, force: force)
-            let result = try fanControllerLocked().setManual(index: index, rpm: target)
+            let result = try writeSMCOperationLocked {
+                try fanControllerLocked().setManual(index: index, rpm: target)
+            }
             ftstGate.enterManual(index: index)
             manualFanTargets[index] = target
             fanCurveEngines.removeAll()
@@ -590,7 +593,7 @@ public final class SmctlDaemon: @unchecked Sendable {
             throw DaemonError.unsupported("Charging control keys are not available on this Mac/system.")
         }
         for write in enabled ? group.enableWrites : group.disableWrites {
-            try backend.writeKey(write.key, bytes: write.bytes)
+            try writeSMCKeyLocked(write.key, bytes: write.bytes, backend: backend)
         }
     }
 
@@ -602,7 +605,29 @@ public final class SmctlDaemon: @unchecked Sendable {
             throw DaemonError.unsupported("Adapter control keys are not available on this Mac/system.")
         }
         for write in enabled ? group.enableWrites : group.disableWrites {
-            try backend.writeKey(write.key, bytes: write.bytes)
+            try writeSMCKeyLocked(write.key, bytes: write.bytes, backend: backend)
+        }
+    }
+
+    private func writeSMCKeyLocked(_ key: String, bytes: [UInt8], backend: any SMCWriteBackend) throws {
+        do {
+            try backend.writeKey(key, bytes: bytes)
+            lastWriteError = nil
+        } catch {
+            lastWriteError = "\(key): \(String(describing: error))"
+            throw error
+        }
+    }
+
+    @discardableResult
+    private func writeSMCOperationLocked<T>(_ operation: () throws -> T) throws -> T {
+        do {
+            let result = try operation()
+            lastWriteError = nil
+            return result
+        } catch {
+            lastWriteError = String(describing: error)
+            throw error
         }
     }
 
@@ -714,7 +739,7 @@ public final class SmctlDaemon: @unchecked Sendable {
             samples: samples,
             guardTripped: latched,
             guardReason: latched ? "Fan safety guard latched (overheat or unreadable temperature sensors)" : nil,
-            writeError: lastError
+            writeError: lastWriteError
         )
         let events = alertEngine.evaluate(rules: rules, input: input, now: Date())
         guard !events.isEmpty else { return }
@@ -799,7 +824,9 @@ public final class SmctlDaemon: @unchecked Sendable {
         }
         let controller = try fanControllerLocked()
         for (index, rpm) in manualFanTargets.sorted(by: { $0.key < $1.key }) {
-            _ = try controller.setManual(index: index, rpm: rpm)
+            _ = try writeSMCOperationLocked {
+                try controller.setManual(index: index, rpm: rpm)
+            }
             ftstGate.enterManual(index: index)
         }
     }
@@ -817,7 +844,9 @@ public final class SmctlDaemon: @unchecked Sendable {
             let evaluation = try engine.evaluate(curve: curve, samples: samples, now: Date())
             fanCurveEngines[fan.index] = engine
             let target = min(maximum, max(minimum, evaluation.targetRPM))
-            _ = try controller.setManual(index: fan.index, rpm: target)
+            _ = try writeSMCOperationLocked {
+                try controller.setManual(index: fan.index, rpm: target)
+            }
             ftstGate.enterManual(index: fan.index)
         }
     }
@@ -866,7 +895,9 @@ public final class SmctlDaemon: @unchecked Sendable {
             let laterRestores = ordered.suffix(from: offset + 1)
             let otherManual = ftstGate.otherManualFansRemain(afterLeaving: index)
                 || laterRestores.isEmpty == false
-            try controller.setAuto(index: index, otherManualFansRemaining: otherManual)
+            try writeSMCOperationLocked {
+                try controller.setAuto(index: index, otherManualFansRemaining: otherManual)
+            }
             _ = ftstGate.leaveManual(index: index)
             manualFanTargets.removeValue(forKey: index)
         }

--- a/Sources/SMCtlProtocol/SMCtlProtocol.swift
+++ b/Sources/SMCtlProtocol/SMCtlProtocol.swift
@@ -36,6 +36,8 @@ public protocol SMCtlDaemonXPCProtocol {
     func setChargeLimit(_ requestData: Data, withReply reply: @escaping (Data?, String?) -> Void)
     func setChargingEnabled(_ requestData: Data, withReply reply: @escaping (Data?, String?) -> Void)
     func setAdapterEnabled(_ requestData: Data, withReply reply: @escaping (Data?, String?) -> Void)
+    func getAlertStatus(withReply reply: @escaping (Data?, String?) -> Void)
+    func testAlert(_ requestData: Data, withReply reply: @escaping (Data?, String?) -> Void)
     func reloadConfig(withReply reply: @escaping (Data?, String?) -> Void)
 }
 
@@ -243,6 +245,58 @@ public struct SetFanAutoRequestDTO: Codable, Equatable, Sendable {
 }
 
 public struct SetFanProfileRequestDTO: Codable, Equatable, Sendable {
+    public var name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}
+
+public struct AlertRuleStateDTO: Codable, Equatable, Sendable {
+    public var name: String
+    public var status: String
+    public var lastFired: Date?
+    public var lastValue: Double?
+
+    public init(name: String, status: String, lastFired: Date?, lastValue: Double?) {
+        self.name = name
+        self.status = status
+        self.lastFired = lastFired
+        self.lastValue = lastValue
+    }
+}
+
+public struct AlertEventDTO: Codable, Equatable, Sendable {
+    public var ruleName: String
+    public var kind: String
+    public var trigger: String
+    public var reason: String
+    public var value: Double?
+    public var timestamp: Date
+
+    public init(ruleName: String, kind: String, trigger: String, reason: String, value: Double?, timestamp: Date) {
+        self.ruleName = ruleName
+        self.kind = kind
+        self.trigger = trigger
+        self.reason = reason
+        self.value = value
+        self.timestamp = timestamp
+    }
+}
+
+public struct AlertStatusDTO: Codable, Equatable, Sendable {
+    public var timestamp: Date
+    public var rules: [AlertRuleStateDTO]
+    public var recent: [AlertEventDTO]
+
+    public init(timestamp: Date, rules: [AlertRuleStateDTO], recent: [AlertEventDTO]) {
+        self.timestamp = timestamp
+        self.rules = rules
+        self.recent = recent
+    }
+}
+
+public struct TestAlertRequestDTO: Codable, Equatable, Sendable {
     public var name: String
 
     public init(name: String) {

--- a/Sources/smctl/main.swift
+++ b/Sources/smctl/main.swift
@@ -24,7 +24,7 @@ struct SMCtl: ParsableCommand {
         commandName: "smctl",
         abstract: "Mac hardware control utility.",
         version: SMCtlProtocolInfo.version,
-        subcommands: [Sensors.self, Fan.self, Battery.self, Power.self, Daemon.self, Debug.self]
+        subcommands: [Sensors.self, Fan.self, Battery.self, Power.self, Alert.self, Daemon.self, Debug.self]
     )
 }
 
@@ -428,6 +428,63 @@ private func watts(_ value: Double?) -> String {
     return "\(String(format: "%.2f", value)) W"
 }
 
+struct Alert: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "alert",
+        abstract: "Inspect and test temperature/event alerts (configured in /etc/smctl/config.toml).",
+        subcommands: [AlertStatus.self, AlertTest.self],
+        defaultSubcommand: AlertStatus.self
+    )
+}
+
+struct AlertStatus: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "status", abstract: "Per-rule state (armed/pending/cooling/firing) and recent events.")
+
+    @Flag(name: .long, help: "Print machine-readable JSON.")
+    var json = false
+
+    func run() throws {
+        let status: AlertStatusDTO = try DaemonClient().getAlertStatus()
+        if json {
+            print(try CLIJSON.encodeString(status))
+            return
+        }
+        printAlertStatus(status)
+    }
+}
+
+struct AlertTest: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "test", abstract: "Fire a configured alert's action immediately, to verify it works.")
+
+    @Argument(help: "Name of the alert rule to test.")
+    var name: String
+
+    func run() throws {
+        try DaemonClient().testAlert(name: name)
+        print("Fired action for alert '\(name)'. Check your webhook/command (or `log show --predicate 'subsystem == \"one.leaper.smctl\"'`).")
+    }
+}
+
+private func printAlertStatus(_ status: AlertStatusDTO) {
+    print("Alerts")
+    if status.rules.isEmpty {
+        print("  No alert rules configured. Add [[alert]] tables to /etc/smctl/config.toml.")
+    } else {
+        for rule in status.rules {
+            let fired = rule.lastFired.map { " last fired \(CLIFormatters.iso8601.string(from: $0))" } ?? ""
+            print("  \(rule.name): \(rule.status)\(fired)")
+        }
+    }
+    if !status.recent.isEmpty {
+        print("")
+        print("Recent events")
+        for event in status.recent.suffix(10) {
+            let when = CLIFormatters.iso8601.string(from: event.timestamp)
+            print("  \(when)  \(event.ruleName) \(event.kind): \(event.reason)")
+        }
+    }
+}
+
 struct Daemon: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "daemon",
@@ -739,6 +796,19 @@ private final class DaemonClient {
     func getDaemonStatus() throws -> DaemonStatusDTO {
         try call { proxy, reply in
             proxy.getDaemonStatus(withReply: reply)
+        }
+    }
+
+    func getAlertStatus() throws -> AlertStatusDTO {
+        try call { proxy, reply in
+            proxy.getAlertStatus(withReply: reply)
+        }
+    }
+
+    func testAlert(name: String) throws {
+        let data = try SMCtlProtocolCoding.encode(TestAlertRequestDTO(name: name))
+        let _: EmptyResponseDTO = try call { proxy, reply in
+            proxy.testAlert(data, withReply: reply)
         }
     }
 

--- a/Tests/PolicyEngineTests/AlertEngineTests.swift
+++ b/Tests/PolicyEngineTests/AlertEngineTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import PolicyEngine
+
+final class AlertEngineTests: XCTestCase {
+    private let base = Date(timeIntervalSince1970: 1_000_000)
+
+    private func tempRule(for seconds: Double = 0, cooldown: Double = 300, resolve: Bool = false) -> AlertRule {
+        AlertRule(
+            name: "cpu-hot",
+            trigger: AlertTrigger(kind: .temp, sensor: "Tp09", above: 85),
+            forSeconds: seconds,
+            cooldownSeconds: cooldown,
+            resolve: resolve
+        )
+    }
+
+    private func input(_ celsius: Double, sensor: String = "Tp09") -> AlertConditionInput {
+        AlertConditionInput(samples: [FanTemperatureSample(sensor: sensor, celsius: celsius)])
+    }
+
+    func testFiresWhenThresholdExceeded() {
+        var engine = AlertEngine()
+        let events = engine.evaluate(rules: [tempRule()], input: input(90), now: base)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.kind, .fired)
+        XCTAssertEqual(events.first?.value, 90)
+        XCTAssertEqual(events.first?.triggerKind, .temp)
+    }
+
+    func testDoesNotFireBelowThreshold() {
+        var engine = AlertEngine()
+        XCTAssertTrue(engine.evaluate(rules: [tempRule()], input: input(80), now: base).isEmpty)
+    }
+
+    func testSustainedDurationDebounce() {
+        var engine = AlertEngine()
+        let rule = tempRule(for: 30)
+        // First tick over threshold starts the timer but does not fire.
+        XCTAssertTrue(engine.evaluate(rules: [rule], input: input(90), now: base).isEmpty)
+        // 20s later: still within the window.
+        XCTAssertTrue(engine.evaluate(rules: [rule], input: input(90), now: base.addingTimeInterval(20)).isEmpty)
+        // 30s later: fires.
+        let fired = engine.evaluate(rules: [rule], input: input(90), now: base.addingTimeInterval(30))
+        XCTAssertEqual(fired.count, 1)
+        XCTAssertEqual(fired.first?.kind, .fired)
+    }
+
+    func testDebounceResetsWhenConditionDrops() {
+        var engine = AlertEngine()
+        let rule = tempRule(for: 30)
+        _ = engine.evaluate(rules: [rule], input: input(90), now: base)
+        // Drops below threshold before the window elapses → timer resets.
+        _ = engine.evaluate(rules: [rule], input: input(70), now: base.addingTimeInterval(10))
+        // Back over threshold; only now does a fresh 30s window start.
+        _ = engine.evaluate(rules: [rule], input: input(90), now: base.addingTimeInterval(20))
+        XCTAssertTrue(engine.evaluate(rules: [rule], input: input(90), now: base.addingTimeInterval(40)).isEmpty)
+        XCTAssertEqual(engine.evaluate(rules: [rule], input: input(90), now: base.addingTimeInterval(50)).count, 1)
+    }
+
+    func testCooldownSuppressesRefiring() {
+        var engine = AlertEngine()
+        let rule = tempRule(cooldown: 300)
+        XCTAssertEqual(engine.evaluate(rules: [rule], input: input(90), now: base).count, 1)
+        // Still hot 100s later, but inside cooldown → silent.
+        XCTAssertTrue(engine.evaluate(rules: [rule], input: input(95), now: base.addingTimeInterval(100)).isEmpty)
+        // After cooldown elapses → fires again.
+        XCTAssertEqual(engine.evaluate(rules: [rule], input: input(95), now: base.addingTimeInterval(301)).count, 1)
+    }
+
+    func testResolveEmitsWhenCleared() {
+        var engine = AlertEngine()
+        let rule = tempRule(resolve: true)
+        XCTAssertEqual(engine.evaluate(rules: [rule], input: input(90), now: base).first?.kind, .fired)
+        let resolved = engine.evaluate(rules: [rule], input: input(70), now: base.addingTimeInterval(10))
+        XCTAssertEqual(resolved.count, 1)
+        XCTAssertEqual(resolved.first?.kind, .resolved)
+    }
+
+    func testNoResolveWhenDisabled() {
+        var engine = AlertEngine()
+        let rule = tempRule(resolve: false)
+        _ = engine.evaluate(rules: [rule], input: input(90), now: base)
+        XCTAssertTrue(engine.evaluate(rules: [rule], input: input(70), now: base.addingTimeInterval(10)).isEmpty)
+    }
+
+    func testAnySensorMatchesHottest() {
+        var engine = AlertEngine()
+        let rule = AlertRule(name: "any-hot", trigger: AlertTrigger(kind: .temp, sensor: "any", above: 85))
+        let multi = AlertConditionInput(samples: [
+            FanTemperatureSample(sensor: "Tp01", celsius: 60),
+            FanTemperatureSample(sensor: "Tp09", celsius: 92),
+            FanTemperatureSample(sensor: "Tg05", celsius: 88)
+        ])
+        let events = engine.evaluate(rules: [rule], input: multi, now: base)
+        XCTAssertEqual(events.first?.value, 92)
+        XCTAssertEqual(events.first?.reason.contains("Tp09"), true)
+    }
+
+    func testGuardTrigger() {
+        var engine = AlertEngine()
+        let rule = AlertRule(name: "guard", trigger: AlertTrigger(kind: .guardTripped))
+        let tripped = AlertConditionInput(guardTripped: true, guardReason: "Tp09 105C")
+        let events = engine.evaluate(rules: [rule], input: tripped, now: base)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.reason, "Tp09 105C")
+    }
+
+    func testWriteErrorTrigger() {
+        var engine = AlertEngine()
+        let rule = AlertRule(name: "smc", trigger: AlertTrigger(kind: .writeError))
+        let err = AlertConditionInput(writeError: "CH0B verify failed")
+        XCTAssertEqual(engine.evaluate(rules: [rule], input: err, now: base).first?.reason, "CH0B verify failed")
+    }
+
+    func testStatesReportLifecycle() {
+        var engine = AlertEngine()
+        let rule = tempRule(cooldown: 300)
+        XCTAssertEqual(engine.states(for: [rule], now: base).first?.status, .armed)
+        _ = engine.evaluate(rules: [rule], input: input(90), now: base)
+        XCTAssertEqual(engine.states(for: [rule], now: base).first?.status, .cooling)
+        // After cooldown but still hot in runtime, status reflects firing.
+        XCTAssertEqual(engine.states(for: [rule], now: base.addingTimeInterval(400)).first?.status, .firing)
+    }
+
+    func testRemovedRuleStateIsDropped() {
+        var engine = AlertEngine()
+        let rule = tempRule()
+        _ = engine.evaluate(rules: [rule], input: input(90), now: base)
+        // Re-evaluate with an empty rule set; the stale runtime must be purged so a
+        // re-added rule starts armed, not mid-cooldown.
+        _ = engine.evaluate(rules: [], input: input(90), now: base.addingTimeInterval(10))
+        let events = engine.evaluate(rules: [rule], input: input(90), now: base.addingTimeInterval(20))
+        XCTAssertEqual(events.count, 1, "Re-added rule should fire fresh, not be suppressed by purged cooldown")
+    }
+}

--- a/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
+++ b/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
@@ -197,6 +197,47 @@ final class SmctlDaemonTests: XCTestCase {
         XCTAssertEqual(reloaded.config.alerts.first?.resolvedAction, .exec(["/usr/local/bin/notify.sh", "{name}", "{value}"]))
     }
 
+    // MARK: - Alert write-error signal
+
+    func testWriteErrorAlertIgnoresGeneralDaemonError() {
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+        daemon.config.alerts = [AlertConfig(name: "writes", on: "write-error", cooldown: 0, action: "log")]
+
+        daemon.evaluateLocked()
+        XCTAssertNotNil(daemon.daemonStatus().lastError, "test setup should create a general daemon error")
+
+        daemon.tickFanAndAlertsLocked()
+
+        XCTAssertTrue(daemon.alertStatus().recent.isEmpty, "write-error alerts must not fire from generic lastError")
+    }
+
+    func testWriteErrorAlertFiresForSMCWriteFailureAndClearsAfterSuccess() throws {
+        let backend = RecordingBackend()
+        backend.values["BUIC"] = [85]
+        backend.values["CH0B"] = [0]
+        backend.values["CH0C"] = [0]
+        backend.values["AC-W"] = [1]
+        backend.failingWriteKeys = ["CH0B"]
+        let daemon = makeDaemon(backend: backend, capabilities: .oneFanWithCharging)
+        daemon.config.alerts = [AlertConfig(name: "writes", on: "write-error", cooldown: 0, action: "log")]
+
+        try daemon.setChargeLimit("70-80")
+        XCTAssertNotNil(daemon.daemonStatus().lastError)
+
+        daemon.tickFanAndAlertsLocked()
+        var status = daemon.alertStatus()
+        XCTAssertEqual(status.recent.count, 1)
+        XCTAssertEqual(status.recent.first?.trigger, "write-error")
+        XCTAssertEqual(status.recent.first?.reason.contains("CH0B"), true)
+
+        backend.failingWriteKeys = []
+        try daemon.setChargingEnabled(true)
+        daemon.tickFanAndAlertsLocked()
+
+        status = daemon.alertStatus()
+        XCTAssertEqual(status.rules.first?.status, "armed")
+    }
+
     // MARK: - Helpers
 
     private func makeDaemon(backend: RecordingBackend, capabilities: Capabilities) -> SmctlDaemon {
@@ -274,6 +315,7 @@ private extension Capabilities {
 private final class RecordingBackend: SMCWriteBackend {
     var values: [String: [UInt8]] = [:]
     var writes: [(key: String, bytes: [UInt8])] = []
+    var failingWriteKeys: Set<String> = []
 
     func readKeyInfo(_ key: String) throws -> SMCKeyInfo {
         guard let bytes = values[key] else {
@@ -297,6 +339,9 @@ private final class RecordingBackend: SMCWriteBackend {
     }
 
     func writeRawValue(_ key: String, bytes: [UInt8]) throws {
+        if failingWriteKeys.contains(key) {
+            throw SMCError.badCommand
+        }
         writes.append((key, bytes))
         values[key] = bytes
     }

--- a/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
+++ b/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
@@ -146,6 +146,57 @@ final class SmctlDaemonTests: XCTestCase {
         XCTAssertEqual(reloaded.config.battery.limit, "70-80")
     }
 
+    func testAlertConfigDecodesFromToml() throws {
+        try """
+        [battery]
+        limit = "80"
+
+        [[alert]]
+        name = "cpu-hot"
+        on = "temp"
+        sensor = "Tp09"
+        above = 85.0
+        for = 30.0
+        cooldown = 300.0
+        resolve = true
+        action = "webhook"
+        url = "http://gotify.lan/message"
+        """.write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+        XCTAssertEqual(daemon.config.alerts.count, 1)
+        let alert = daemon.config.alerts.first
+        XCTAssertEqual(alert?.name, "cpu-hot")
+        XCTAssertEqual(alert?.above, 85)
+        XCTAssertEqual(alert?.forSeconds, 30)
+        XCTAssertEqual(alert?.rule?.trigger.kind, .temp)
+    }
+
+    func testWriteConfigPreservesAlerts() throws {
+        try """
+        [battery]
+        limit = "80"
+
+        [[alert]]
+        name = "cpu-hot"
+        on = "temp"
+        sensor = "Tp09"
+        above = 85.0
+        action = "exec"
+        command = ["/usr/local/bin/notify.sh", "{name}", "{value}"]
+        """.write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        // A battery write rewrites the whole config file; the alert must survive.
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+        XCTAssertEqual(daemon.config.alerts.count, 1)
+        try daemon.setChargeLimit("70-80")
+
+        let reloaded = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+        XCTAssertEqual(reloaded.config.alerts.count, 1, "writeConfig must round-trip [[alert]] tables")
+        XCTAssertEqual(reloaded.config.alerts.first?.command, ["/usr/local/bin/notify.sh", "{name}", "{value}"])
+        XCTAssertEqual(reloaded.config.alerts.first?.resolvedAction, .exec(["/usr/local/bin/notify.sh", "{name}", "{value}"]))
+    }
+
     // MARK: - Helpers
 
     private func makeDaemon(backend: RecordingBackend, capabilities: Capabilities) -> SmctlDaemon {
@@ -160,6 +211,32 @@ final class SmctlDaemonTests: XCTestCase {
             capabilities: capabilities,
             configPath: configPath
         )
+    }
+}
+
+final class AlertActionRunnerTests: XCTestCase {
+    func testExecRunsSubprocessWithSubstitutedArgv() throws {
+        let marker = NSTemporaryDirectory() + "smctl-alert-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: marker + "-cpu-hot") }
+
+        let runner = AlertActionRunner()
+        let event = AlertEvent(
+            ruleName: "cpu-hot",
+            kind: .fired,
+            triggerKind: .temp,
+            reason: "test",
+            value: 92,
+            timestamp: Date()
+        )
+        // Filename carries {name}; if substitution works the file lands at <marker>-cpu-hot.
+        runner.run(event: event, action: .exec(["/usr/bin/touch", "\(marker)-{name}"]))
+
+        let expected = marker + "-cpu-hot"
+        let deadline = Date().addingTimeInterval(5)
+        while !FileManager.default.fileExists(atPath: expected), Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expected), "exec action should run /usr/bin/touch with {name} substituted")
     }
 }
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -36,6 +36,7 @@ $ smctl sensors --watch            # 实时温度、风扇转速、封装功耗
 | `smctl fan set 2500 [--fan N]` | 手动设定目标转速 |
 | `smctl fan profile quiet\|full\|auto\|<自定义>` | 声明式风扇曲线（TOML），带滞回和变速率限制 |
 | `smctl power status [--watch] [--json]` | 热压制状态、CPU 降频幅度（限速 %）、封装功耗与输入功率 |
+| `smctl alert status\|test <name>` | 温度/事件告警 → webhook、命令或日志（TOML 配置） |
 | `smctl daemon install\|uninstall\|status\|ping` | 管理特权 daemon |
 
 策略配置在 `/etc/smctl/config.toml`——声明式、可 diff、对 dotfiles 友好。
@@ -83,14 +84,47 @@ Homebrew 安装会自动配置 shell 补全（bash/zsh/fish）和 `man smctl` �
 
 ## 隐私
 
-daemon 只发起一种对外网络请求：每天一次查询 GitHub releases API 获取最新版本号，由 CLI 提示你升级。除此之外没有任何数据离开你的机器——无遥测、无统计。关闭方式：在 `/etc/smctl/config.toml` 写入
+daemon 仅在两种情况下发起对外网络请求，且都由你掌控：
+
+1. **更新检查**——每天一次查询 GitHub releases API 获取最新版本号，由 CLI 提示你升级。默认开启，可用 `[update] check = false` 关闭。
+2. **告警 webhook**——只发往*你自己*在 `[[alert]]` 规则里配置的 URL。不配告警（默认）就没有这类请求。
+
+无遥测、无统计。CLI 本身从不发起网络请求——所有对外流量都来自 daemon 的上述两种可开关情况。完全离线：在 `/etc/smctl/config.toml` 写入
 
 ```toml
 [update]
 check = false
 ```
 
-然后 `sudo smctl daemon restart`。CLI 本身从不发起网络请求。
+然后 `sudo smctl daemon restart`，并且不配置任何 webhook 告警。
+
+## 告警
+
+daemon 为了温度护栏，本就每秒扫描所有温度传感器。告警规则挂在同一个循环上：条件满足时 daemon 执行一个动作——shell 命令、HTTP webhook 或一条日志。适合把 Mac mini 服务器接进 Prometheus/Gotify 等告警体系。
+
+规则是 `/etc/smctl/config.toml` 里的声明式 TOML：
+
+```toml
+[[alert]]
+name = "cpu-hot"
+on = "temp"            # temp | guard | write-error
+sensor = "Tp09"        # 传感器键，或 "any" 取最热的一个
+above = 85             # ℃
+for = 30               # 持续满足这么多秒才触发（去抖）
+cooldown = 300         # 触发后静默这么多秒
+resolve = true         # 条件恢复时再发一条
+action = "webhook"     # webhook | exec | log
+url = "http://gotify.lan/message?token=..."
+```
+
+`exec` 命令会同时拿到占位符（`{name}` `{kind}` `{trigger}` `{reason}` `{value}`）和 `SMCTL_ALERT_*` 环境变量。检视与验证：
+
+```console
+$ smctl alert status          # 每条规则的状态 + 最近事件
+$ smctl alert test cpu-hot    # 立即触发动作，验证 webhook/脚本是否通
+```
+
+> **安全提示**：`exec` 动作以 **root** 运行（daemon 是 root）。信任边界 = 能编辑 root 拥有的 `/etc/smctl/config.toml` 的人——与其它所有策略一致。命令只走 argv 数组（不经 shell），无命令注入面，但应把「能改配置」视同 root 权限。
 
 ## 支持的硬件
 


### PR DESCRIPTION
## 做了什么

把告警挂在 daemon **已有的每秒温度监控循环**上（护栏就靠它），所以数据采集成本为零。第一版三类触发源，数据全在手里：

- `temp` —— 传感器持续超阈值
- `guard` —— 风扇安全护栏触发（被强制恢复 auto）
- `write-error` —— SMC 写回读校验失败

动作三种：`webhook`（HTTP POST）/ `exec`（跑命令）/ `log`。

```toml
[[alert]]
name = "cpu-hot"
on = "temp"
sensor = "Tp09"     # 或 "any" 取最热
above = 85
for = 30            # 持续 30s 才触发（去抖）
cooldown = 300      # 触发后静默 300s
resolve = true      # 恢复时再发一条
action = "webhook"
url = "http://gotify.lan/message?token=..."
```

```console
$ smctl alert status        # 每条规则状态(armed/pending/cooling/firing) + 最近事件
$ smctl alert test cpu-hot  # 立即触发动作，验证 webhook/脚本
```

## 架构要点

| 关注点 | 处理 |
|---|---|
| **去抖** | `AlertEngine`（PolicyEngine，纯逻辑边沿状态机）：for 持续时长 + cooldown + 边沿触发，`now` 注入可测 |
| **动作隔离** | `AlertActionRunner` 在**独立队列**跑，绝不阻塞 1Hz 循环；exec/webhook 都有超时；并发闸满了直接丢弃而非堆积；失败只记日志不传播 |
| **配置不丢** | `writeConfig` 序列化 `[[alert]]` —— 否则一次 battery/fan 写入会把用户告警抹掉（已加回归测试） |
| **fanless Mac** | tick 重构为「读一次温度 → 风扇子系统 → 告警」，告警在无风扇机型上也能跑 |

## 安全 / 隐私

- **exec 以 root 运行**（daemon 是 root）。信任边界 = 能编辑 root 拥有的 `/etc/smctl/config.toml` 的人，与 `allow_below_minimum` 完全一致。命令只走 **argv 数组（不经 shell）**，无注入面。
- webhook 是**第二类出站请求**（opt-in）。README / zh-CN 的隐私承诺已相应更新（原来写的是 "exactly one outbound request"）。

## 测试

- 引擎 12 例：超阈值 / 去抖 / 去抖重置 / cooldown / resolve / any 传感器 / guard / write-error / 状态生命周期 / 规则移除后状态清理
- daemon：`[[alert]]` TOML 解码 + **writeConfig 保留告警**回归
- **真实子进程 exec 集成测试**（spawn `/usr/bin/touch` 验证 argv 占位符替换）
- 全套 65 tests 绿

## 未做（诚实说明）

为不干扰用户**已安装的生产 daemon**，没有跑「装新 daemon + 真实 webhook」的线上 E2E。XPC 管线是机械镜像现有可用方法，加上引擎/配置/exec 的单测，作为安全网。合并后建议在干净环境做一次真机 webhook 验收。

## 后续

第 3 步（`alert list` 等增强）与第 4 步（降频转告警、电源策略写入）见路线图。降频数据来自 #1 的 `power status`。