### PR TITLE
feat: alert list 显示规则定义与配置问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ smctl sensors --watch            # live temperatures, fan RPM, package power
 | `smctl fan set 2500 [--fan N]` | Manual fan target |
 | `smctl fan profile quiet\|full\|auto\|<custom>` | Declarative fan curves (TOML), hysteresis + slew-rate limited |
 | `smctl power status [--watch] [--json]` | Thermal pressure, CPU throttling (% speed limit), package + input power |
-| `smctl alert status\|test <name>` | Temperature/event alerts → webhook, command, or log (configured in TOML) |
+| `smctl alert list\|status\|test <name>` | Temperature/event alerts → webhook, command, or log (configured in TOML) |
 | `smctl daemon install\|uninstall\|status\|ping` | Manage the privileged helper |
 
 Policies live in `/etc/smctl/config.toml` — declarative, diffable, dotfiles-friendly.
@@ -128,9 +128,12 @@ command = ["/usr/local/bin/notify.sh", "{name}", "{reason}"]
 `exec` commands receive the event as both substituted argv placeholders (`{name}` `{kind}` `{trigger}` `{reason}` `{value}`) and `SMCTL_ALERT_*` environment variables. Inspect and verify rules with:
 
 ```console
+$ smctl alert list            # configured rules, validity, and redacted action targets
 $ smctl alert status          # per-rule state + recent events
 $ smctl alert test cpu-hot    # fire the action now, to check your webhook/script
 ```
+
+`alert list` deliberately redacts webhook query strings and exec arguments in human and JSON output, so tokens in `/etc/smctl/config.toml` do not leak through the read-only status API.
 
 > **Security:** `exec` actions run as **root** (the daemon is root). The trust boundary is whoever can edit the root-owned `/etc/smctl/config.toml` — the same boundary as every other policy. Commands run via argv arrays only (no shell), so there is no command-injection surface, but treat write access to the config as equivalent to root.
 

--- a/Sources/SMCtlDaemonCore/Alerting.swift
+++ b/Sources/SMCtlDaemonCore/Alerting.swift
@@ -69,7 +69,7 @@ struct AlertConfig: Codable, Equatable, Sendable {
     /// The engine rule, or nil when the config is malformed (unknown trigger kind
     /// or empty name) — invalid rules are dropped, never crash the daemon.
     var rule: AlertRule? {
-        guard !name.isEmpty, let kind = AlertTriggerKind(rawValue: on) else { return nil }
+        guard validationProblem == nil, let kind = AlertTriggerKind(rawValue: on) else { return nil }
         return AlertRule(
             name: name,
             trigger: AlertTrigger(kind: kind, sensor: sensor, above: above),
@@ -90,6 +90,87 @@ struct AlertConfig: Codable, Equatable, Sendable {
         default:
             return .log
         }
+    }
+
+    var definition: AlertRuleDefinitionDTO {
+        let problem = validationProblem
+        return AlertRuleDefinitionDTO(
+            name: name,
+            on: on,
+            sensor: sensor,
+            above: above,
+            forSeconds: forSeconds,
+            cooldown: cooldown,
+            resolve: resolve ?? false,
+            action: resolvedActionName,
+            actionTarget: actionTargetSummary,
+            valid: problem == nil,
+            problem: problem,
+            warnings: actionWarnings
+        )
+    }
+
+    private var validationProblem: String? {
+        if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "missing name"
+        }
+        guard let kind = AlertTriggerKind(rawValue: on) else {
+            return on.isEmpty ? "missing trigger" : "unknown trigger '\(on)'"
+        }
+        if kind == .temp, above == nil {
+            return "temp trigger requires 'above'"
+        }
+        return nil
+    }
+
+    private var resolvedActionName: String {
+        switch resolvedAction {
+        case .webhook:
+            return "webhook"
+        case .exec:
+            return "exec"
+        case .log:
+            return "log"
+        }
+    }
+
+    private var actionTargetSummary: String? {
+        switch resolvedAction {
+        case .webhook(let urlString):
+            return Self.redactedURLSummary(urlString)
+        case .exec(let command):
+            guard let executable = command.first else { return nil }
+            let extraArgs = max(0, command.count - 1)
+            return extraArgs == 0 ? executable : "\(executable) (+\(extraArgs) args)"
+        case .log:
+            return nil
+        }
+    }
+
+    private var actionWarnings: [String] {
+        switch action {
+        case "webhook" where (url ?? "").isEmpty:
+            return ["webhook action missing url; using log"]
+        case "exec" where command?.isEmpty != false:
+            return ["exec action missing command; using log"]
+        case nil, "log":
+            return []
+        case "webhook", "exec":
+            return []
+        case let unknown?:
+            return ["unknown action '\(unknown)'; using log"]
+        }
+    }
+
+    private static func redactedURLSummary(_ urlString: String) -> String {
+        guard var components = URLComponents(string: urlString) else {
+            return "invalid URL"
+        }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? "invalid URL"
     }
 }
 

--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -782,7 +782,12 @@ public final class SmctlDaemon: @unchecked Sendable {
                     timestamp: event.timestamp
                 )
             }
-            return AlertStatusDTO(timestamp: now, rules: states, recent: Array(history))
+            return AlertStatusDTO(
+                timestamp: now,
+                definitions: config.alerts.map(\.definition),
+                rules: states,
+                recent: Array(history)
+            )
         }
     }
 

--- a/Sources/SMCtlProtocol/SMCtlProtocol.swift
+++ b/Sources/SMCtlProtocol/SMCtlProtocol.swift
@@ -266,6 +266,51 @@ public struct AlertRuleStateDTO: Codable, Equatable, Sendable {
     }
 }
 
+public struct AlertRuleDefinitionDTO: Codable, Equatable, Sendable {
+    public var name: String
+    public var on: String
+    public var sensor: String?
+    public var above: Double?
+    public var forSeconds: Double?
+    public var cooldown: Double?
+    public var resolve: Bool
+    public var action: String
+    /// Redacted, read-safe action target. Webhook query strings and exec args are
+    /// intentionally not exposed over the unauthenticated status XPC call.
+    public var actionTarget: String?
+    public var valid: Bool
+    public var problem: String?
+    public var warnings: [String]
+
+    public init(
+        name: String,
+        on: String,
+        sensor: String?,
+        above: Double?,
+        forSeconds: Double?,
+        cooldown: Double?,
+        resolve: Bool,
+        action: String,
+        actionTarget: String?,
+        valid: Bool,
+        problem: String?,
+        warnings: [String] = []
+    ) {
+        self.name = name
+        self.on = on
+        self.sensor = sensor
+        self.above = above
+        self.forSeconds = forSeconds
+        self.cooldown = cooldown
+        self.resolve = resolve
+        self.action = action
+        self.actionTarget = actionTarget
+        self.valid = valid
+        self.problem = problem
+        self.warnings = warnings
+    }
+}
+
 public struct AlertEventDTO: Codable, Equatable, Sendable {
     public var ruleName: String
     public var kind: String
@@ -286,11 +331,18 @@ public struct AlertEventDTO: Codable, Equatable, Sendable {
 
 public struct AlertStatusDTO: Codable, Equatable, Sendable {
     public var timestamp: Date
+    public var definitions: [AlertRuleDefinitionDTO]?
     public var rules: [AlertRuleStateDTO]
     public var recent: [AlertEventDTO]
 
-    public init(timestamp: Date, rules: [AlertRuleStateDTO], recent: [AlertEventDTO]) {
+    public init(
+        timestamp: Date,
+        definitions: [AlertRuleDefinitionDTO]? = nil,
+        rules: [AlertRuleStateDTO],
+        recent: [AlertEventDTO]
+    ) {
         self.timestamp = timestamp
+        self.definitions = definitions
         self.rules = rules
         self.recent = recent
     }

--- a/Sources/smctl/main.swift
+++ b/Sources/smctl/main.swift
@@ -432,9 +432,26 @@ struct Alert: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "alert",
         abstract: "Inspect and test temperature/event alerts (configured in /etc/smctl/config.toml).",
-        subcommands: [AlertStatus.self, AlertTest.self],
+        subcommands: [AlertList.self, AlertStatus.self, AlertTest.self],
         defaultSubcommand: AlertStatus.self
     )
+}
+
+struct AlertList: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "Show configured alert rules and read-safe action summaries.")
+
+    @Flag(name: .long, help: "Print machine-readable JSON.")
+    var json = false
+
+    func run() throws {
+        let status: AlertStatusDTO = try DaemonClient().getAlertStatus()
+        let definitions = status.definitions ?? []
+        if json {
+            print(try CLIJSON.encodeString(definitions))
+            return
+        }
+        printAlertDefinitions(definitions)
+    }
 }
 
 struct AlertStatus: ParsableCommand {
@@ -468,7 +485,11 @@ struct AlertTest: ParsableCommand {
 private func printAlertStatus(_ status: AlertStatusDTO) {
     print("Alerts")
     if status.rules.isEmpty {
-        print("  No alert rules configured. Add [[alert]] tables to /etc/smctl/config.toml.")
+        if status.definitions?.isEmpty == false {
+            print("  No valid alert rules. Run `smctl alert list` to inspect config problems.")
+        } else {
+            print("  No alert rules configured. Add [[alert]] tables to /etc/smctl/config.toml.")
+        }
     } else {
         for rule in status.rules {
             let fired = rule.lastFired.map { " last fired \(CLIFormatters.iso8601.string(from: $0))" } ?? ""
@@ -483,6 +504,61 @@ private func printAlertStatus(_ status: AlertStatusDTO) {
             print("  \(when)  \(event.ruleName) \(event.kind): \(event.reason)")
         }
     }
+}
+
+private func printAlertDefinitions(_ definitions: [AlertRuleDefinitionDTO]) {
+    print("Alert rules")
+    guard !definitions.isEmpty else {
+        print("  No alert rules configured. Add [[alert]] tables to /etc/smctl/config.toml.")
+        return
+    }
+
+    for definition in definitions {
+        let name = definition.name.isEmpty ? "<unnamed>" : definition.name
+        if definition.valid {
+            print("  \(name): \(alertTriggerDescription(definition)); action \(alertActionDescription(definition))")
+        } else {
+            print("  \(name): invalid - \(definition.problem ?? "unknown problem")")
+        }
+        for warning in definition.warnings {
+            print("    warning: \(warning)")
+        }
+    }
+}
+
+private func alertTriggerDescription(_ definition: AlertRuleDefinitionDTO) -> String {
+    var parts = [definition.on]
+    if let sensor = definition.sensor, !sensor.isEmpty {
+        parts.append("sensor \(sensor)")
+    }
+    if let above = definition.above {
+        parts.append("above \(formatNumber(above))C")
+    }
+    if let forSeconds = definition.forSeconds {
+        parts.append("for \(formatSeconds(forSeconds))")
+    }
+    if let cooldown = definition.cooldown {
+        parts.append("cooldown \(formatSeconds(cooldown))")
+    }
+    if definition.resolve {
+        parts.append("resolve")
+    }
+    return parts.joined(separator: ", ")
+}
+
+private func alertActionDescription(_ definition: AlertRuleDefinitionDTO) -> String {
+    if let target = definition.actionTarget, !target.isEmpty {
+        return "\(definition.action) \(target)"
+    }
+    return definition.action
+}
+
+private func formatSeconds(_ value: Double) -> String {
+    "\(formatNumber(value))s"
+}
+
+private func formatNumber(_ value: Double) -> String {
+    value.rounded() == value ? String(Int(value)) : String(format: "%.1f", value)
 }
 
 struct Daemon: ParsableCommand {

--- a/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
+++ b/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
@@ -197,6 +197,44 @@ final class SmctlDaemonTests: XCTestCase {
         XCTAssertEqual(reloaded.config.alerts.first?.resolvedAction, .exec(["/usr/local/bin/notify.sh", "{name}", "{value}"]))
     }
 
+    func testAlertStatusIncludesDefinitionsAndInvalidRules() throws {
+        try """
+        [[alert]]
+        name = "cpu-hot"
+        on = "temp"
+        sensor = "Tp09"
+        above = 85.0
+        for = 30.0
+        cooldown = 300.0
+        resolve = true
+        action = "webhook"
+        url = "https://gotify.lan/message?token=secret"
+
+        [[alert]]
+        name = "broken"
+        on = "temp"
+        action = "exec"
+        command = ["/usr/local/bin/notify.sh", "secret-token"]
+        """.write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+        let status = daemon.alertStatus()
+
+        XCTAssertEqual(status.rules.map(\.name), ["cpu-hot"], "only valid rules should enter the alert engine")
+        XCTAssertEqual(status.definitions?.count, 2)
+        let valid = status.definitions?.first { $0.name == "cpu-hot" }
+        XCTAssertEqual(valid?.valid, true)
+        XCTAssertEqual(valid?.action, "webhook")
+        XCTAssertEqual(valid?.actionTarget, "https://gotify.lan/message")
+        XCTAssertFalse(valid?.actionTarget?.contains("secret") ?? true, "status must not leak webhook query tokens")
+
+        let broken = status.definitions?.first { $0.name == "broken" }
+        XCTAssertEqual(broken?.valid, false)
+        XCTAssertEqual(broken?.problem, "temp trigger requires 'above'")
+        XCTAssertEqual(broken?.actionTarget, "/usr/local/bin/notify.sh (+1 args)")
+        XCTAssertFalse(broken?.actionTarget?.contains("secret") ?? true, "status must not leak exec argv secrets")
+    }
+
     // MARK: - Alert write-error signal
 
     func testWriteErrorAlertIgnoresGeneralDaemonError() {

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -36,7 +36,7 @@ $ smctl sensors --watch            # 实时温度、风扇转速、封装功耗
 | `smctl fan set 2500 [--fan N]` | 手动设定目标转速 |
 | `smctl fan profile quiet\|full\|auto\|<自定义>` | 声明式风扇曲线（TOML），带滞回和变速率限制 |
 | `smctl power status [--watch] [--json]` | 热压制状态、CPU 降频幅度（限速 %）、封装功耗与输入功率 |
-| `smctl alert status\|test <name>` | 温度/事件告警 → webhook、命令或日志（TOML 配置） |
+| `smctl alert list\|status\|test <name>` | 温度/事件告警 → webhook、命令或日志（TOML 配置） |
 | `smctl daemon install\|uninstall\|status\|ping` | 管理特权 daemon |
 
 策略配置在 `/etc/smctl/config.toml`——声明式、可 diff、对 dotfiles 友好。
@@ -120,9 +120,12 @@ url = "http://gotify.lan/message?token=..."
 `exec` 命令会同时拿到占位符（`{name}` `{kind}` `{trigger}` `{reason}` `{value}`）和 `SMCTL_ALERT_*` 环境变量。检视与验证：
 
 ```console
+$ smctl alert list            # 规则定义、有效性、脱敏后的动作目标
 $ smctl alert status          # 每条规则的状态 + 最近事件
 $ smctl alert test cpu-hot    # 立即触发动作，验证 webhook/脚本是否通
 ```
+
+`alert list` 在普通文本和 JSON 输出里都会隐藏 webhook query string 与 exec 参数，避免 `/etc/smctl/config.toml` 里的 token 通过只读状态 API 泄露。
 
 > **安全提示**：`exec` 动作以 **root** 运行（daemon 是 root）。信任边界 = 能编辑 root 拥有的 `/etc/smctl/config.toml` 的人——与其它所有策略一致。命令只走 argv 数组（不经 shell），无命令注入面，但应把「能改配置」视同 root 权限。
 


### PR DESCRIPTION
## Summary

- add `smctl alert list` for configured alert definitions, including invalid rules ignored by the engine
- expose read-safe alert definition DTOs through alert status, with webhook query strings and exec arguments redacted
- document the new command and add regression coverage for invalid-rule visibility and secret redaction

## Validation

- `swift test --disable-sandbox` (75 tests)
- `git diff --check`
- `.build/debug/smctl alert --help`
- `.build/debug/smctl alert list --help`
