### PR TITLE
fix: Apple Silicon integer SMC decoding (si8/si16, endianness) + daemon crash on unauthorized XPC write

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ smctl sensors --watch            # live temperatures, fan RPM, package power
 | `smctl fan status` | Per-fan actual/target/min/max RPM and control mode |
 | `smctl fan set 2500 [--fan N]` | Manual fan target |
 | `smctl fan profile quiet\|full\|auto\|<custom>` | Declarative fan curves (TOML), hysteresis + slew-rate limited |
-| `smctl power status [--watch] [--json]` | Thermal pressure, CPU throttling (% speed limit), package + input power |
+| `smctl power status [--watch] [--json]` | Thermal pressure, CPU throttling (% speed limit), system/package + input power |
 | `smctl alert list\|status\|test <name>` | Temperature/event alerts → webhook, command, or log (configured in TOML) |
 | `smctl daemon install\|uninstall\|status\|ping` | Manage the privileged helper |
 

--- a/Sources/SMCCore/KeyCatalog.swift
+++ b/Sources/SMCCore/KeyCatalog.swift
@@ -103,7 +103,7 @@ public struct KeyCatalog {
     public init(
         temperatureCandidates: [String] = KeyCatalog.defaultTemperatureCandidates,
         batteryCandidates: [String] = ["BUIC", "B0AC", "B0AV", "PPBR", "AC-W"],
-        powerCandidates: [String] = ["PDTR", "ID0R", "VD0R"],
+        powerCandidates: [String] = ["PDTR", "PSTR", "ID0R", "VD0R"],
         chargingControlCandidates: [SMCControlKeyGroup] = KeyCatalog.defaultChargingControlCandidates,
         adapterControlCandidates: [SMCControlKeyGroup] = KeyCatalog.defaultAdapterControlCandidates
     ) {

--- a/Sources/SMCCore/PowerStatus.swift
+++ b/Sources/SMCCore/PowerStatus.swift
@@ -62,8 +62,12 @@ public struct PowerSnapshot: Codable, Equatable, Sendable {
     public var timestamp: Date
     public var thermalPressure: ThermalPressure
     public var cpu: CPUThrottleStatus
-    /// PDTR — package power in watts.
+    /// PDTR — DC-in total power in watts. Legitimately ~0 when running on
+    /// battery (it measures adapter delivery, not consumption).
     public var packagePowerWatts: Double?
+    /// PSTR — system total power in watts. Meaningful on both AC and battery;
+    /// the better "what is the machine drawing" signal on portables.
+    public var systemPowerWatts: Double?
     /// VD0R — DC input voltage in volts.
     public var inputVoltage: Double?
     /// ID0R — DC input current in amps.
@@ -74,6 +78,7 @@ public struct PowerSnapshot: Codable, Equatable, Sendable {
         thermalPressure: ThermalPressure,
         cpu: CPUThrottleStatus,
         packagePowerWatts: Double?,
+        systemPowerWatts: Double?,
         inputVoltage: Double?,
         inputCurrent: Double?
     ) {
@@ -81,6 +86,7 @@ public struct PowerSnapshot: Codable, Equatable, Sendable {
         self.thermalPressure = thermalPressure
         self.cpu = cpu
         self.packagePowerWatts = packagePowerWatts
+        self.systemPowerWatts = systemPowerWatts
         self.inputVoltage = inputVoltage
         self.inputCurrent = inputCurrent
     }
@@ -92,7 +98,7 @@ public struct PowerSnapshot: Codable, Equatable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case timestamp, thermalPressure, cpu, packagePowerWatts
+        case timestamp, thermalPressure, cpu, packagePowerWatts, systemPowerWatts
         case inputVoltage, inputCurrent, inputPowerWatts
     }
 
@@ -102,6 +108,7 @@ public struct PowerSnapshot: Codable, Equatable, Sendable {
         try container.encode(thermalPressure, forKey: .thermalPressure)
         try container.encode(cpu, forKey: .cpu)
         try container.encodeIfPresent(packagePowerWatts, forKey: .packagePowerWatts)
+        try container.encodeIfPresent(systemPowerWatts, forKey: .systemPowerWatts)
         try container.encodeIfPresent(inputVoltage, forKey: .inputVoltage)
         try container.encodeIfPresent(inputCurrent, forKey: .inputCurrent)
         try container.encodeIfPresent(inputPowerWatts, forKey: .inputPowerWatts)
@@ -113,6 +120,7 @@ public struct PowerSnapshot: Codable, Equatable, Sendable {
         thermalPressure = try container.decode(ThermalPressure.self, forKey: .thermalPressure)
         cpu = try container.decode(CPUThrottleStatus.self, forKey: .cpu)
         packagePowerWatts = try container.decodeIfPresent(Double.self, forKey: .packagePowerWatts)
+        systemPowerWatts = try container.decodeIfPresent(Double.self, forKey: .systemPowerWatts)
         inputVoltage = try container.decodeIfPresent(Double.self, forKey: .inputVoltage)
         inputCurrent = try container.decodeIfPresent(Double.self, forKey: .inputCurrent)
     }
@@ -180,6 +188,7 @@ public final class PowerReader {
             thermalPressure: ThermalPressure(thermalStateProvider()),
             cpu: cpu,
             packagePowerWatts: numericValue("PDTR"),
+            systemPowerWatts: numericValue("PSTR"),
             inputVoltage: numericValue("VD0R"),
             inputCurrent: numericValue("ID0R")
         )

--- a/Sources/SMCCore/SMCDataDecoder.swift
+++ b/Sources/SMCCore/SMCDataDecoder.swift
@@ -17,8 +17,33 @@ public enum SMCDecodedValue: Equatable, Codable {
     }
 }
 
+/// Byte order of multi-byte SMC integer types (ui16/ui32/si16/si32).
+///
+/// Apple Silicon SMC stores integers little-endian; Intel SMC stores them
+/// big-endian. Verified on M2 (B0AV as little-endian matches the
+/// AppleSmartBattery IOKit voltage within a few mV; big-endian decodes to
+/// garbage). `flt` is always little-endian IEEE 754, and the legacy
+/// fixed-point types (fpe2/sp78) are Intel-era formats defined big-endian.
+public enum SMCIntegerByteOrder: Sendable {
+    case little
+    case big
+
+    public static var platform: SMCIntegerByteOrder {
+        #if arch(arm64)
+        return .little
+        #else
+        return .big
+        #endif
+    }
+}
+
 public enum SMCDataDecoder {
-    public static func decode(key: String, bytes: [UInt8], dataType: UInt32) throws -> SMCDecodedValue {
+    public static func decode(
+        key: String,
+        bytes: [UInt8],
+        dataType: UInt32,
+        integerByteOrder: SMCIntegerByteOrder = .platform
+    ) throws -> SMCDecodedValue {
         let types = FourCharCode.normalizedStrings(dataType)
 
         if types.contains("flt ") || types.contains("flt") {
@@ -48,22 +73,56 @@ public enum SMCDataDecoder {
             return .unsigned(UInt32(bytes[0]))
         }
 
+        if types.contains("si8 ") || types.contains("si8") {
+            try require(bytes, count: 1, key: key, type: "si8")
+            return .number(Double(Int8(bitPattern: bytes[0])))
+        }
+
         if types.contains("ui16") {
             try require(bytes, count: 2, key: key, type: "ui16")
-            let raw = UInt16(bytes[0]) << 8 | UInt16(bytes[1])
-            return .unsigned(UInt32(raw))
+            return .unsigned(UInt32(uint16(bytes, integerByteOrder)))
+        }
+
+        if types.contains("si16") {
+            try require(bytes, count: 2, key: key, type: "si16")
+            return .number(Double(Int16(bitPattern: uint16(bytes, integerByteOrder))))
         }
 
         if types.contains("ui32") {
             try require(bytes, count: 4, key: key, type: "ui32")
-            let raw = UInt32(bytes[0]) << 24
-                | UInt32(bytes[1]) << 16
-                | UInt32(bytes[2]) << 8
-                | UInt32(bytes[3])
-            return .unsigned(raw)
+            return .unsigned(uint32(bytes, integerByteOrder))
+        }
+
+        if types.contains("si32") {
+            try require(bytes, count: 4, key: key, type: "si32")
+            return .number(Double(Int32(bitPattern: uint32(bytes, integerByteOrder))))
         }
 
         return .bytes(bytes)
+    }
+
+    private static func uint16(_ bytes: [UInt8], _ order: SMCIntegerByteOrder) -> UInt16 {
+        switch order {
+        case .big:
+            return UInt16(bytes[0]) << 8 | UInt16(bytes[1])
+        case .little:
+            return UInt16(bytes[1]) << 8 | UInt16(bytes[0])
+        }
+    }
+
+    private static func uint32(_ bytes: [UInt8], _ order: SMCIntegerByteOrder) -> UInt32 {
+        switch order {
+        case .big:
+            return UInt32(bytes[0]) << 24
+                | UInt32(bytes[1]) << 16
+                | UInt32(bytes[2]) << 8
+                | UInt32(bytes[3])
+        case .little:
+            return UInt32(bytes[3]) << 24
+                | UInt32(bytes[2]) << 16
+                | UInt32(bytes[1]) << 8
+                | UInt32(bytes[0])
+        }
     }
 
     private static func require(_ bytes: [UInt8], count: Int, key: String, type: String) throws {

--- a/Sources/SMCCore/SensorSnapshot.swift
+++ b/Sources/SMCCore/SensorSnapshot.swift
@@ -61,16 +61,17 @@ public final class SensorReader {
             temperatures: readTemperatures(keys: capabilities.temperatureKeys),
             fans: readFans(capabilities.fans),
             battery: readNamedReadings([
-                ("BUIC", "Charge", "%"),
-                ("B0AC", "Current", "A"),
-                ("B0AV", "Voltage", "V"),
-                ("PPBR", "Battery Power", "W"),
-                ("AC-W", "Adapter Power", "W")
+                ("BUIC", "Charge", "%", 1),
+                ("B0AC", "Current", "A", 0.001),  // si16 in mA
+                ("B0AV", "Voltage", "V", 0.001),  // ui16 in mV
+                ("PPBR", "Battery Power", "W", 1),
+                ("AC-W", "Adapter Power", "W", 1)
             ], availableKeys: capabilities.batteryKeys),
             power: readNamedReadings([
-                ("PDTR", "Package Power", "W"),
-                ("ID0R", "Input Current", "A"),
-                ("VD0R", "Input Voltage", "V")
+                ("PDTR", "Package Power", "W", 1),
+                ("PSTR", "System Power", "W", 1),
+                ("ID0R", "Input Current", "A", 1),
+                ("VD0R", "Input Voltage", "V", 1)
             ], availableKeys: capabilities.powerKeys)
         )
     }
@@ -112,18 +113,18 @@ public final class SensorReader {
         }
     }
 
-    private func readNamedReadings(_ readings: [(String, String, String)], availableKeys: [String]) -> [NamedReading] {
+    private func readNamedReadings(_ readings: [(String, String, String, Double)], availableKeys: [String]) -> [NamedReading] {
         let available = Set(availableKeys)
-        return readings.compactMap { key, name, unit in
+        return readings.compactMap { key, name, unit, scale in
             guard available.contains(key), let value = try? backend.readValue(key) else {
                 return nil
             }
 
             switch value.decoded {
             case .number(let number):
-                return NamedReading(key: key, name: name, value: number, rawBytes: nil, unit: unit, dataType: value.info.dataTypeString)
+                return NamedReading(key: key, name: name, value: number * scale, rawBytes: nil, unit: unit, dataType: value.info.dataTypeString)
             case .unsigned(let unsigned):
-                return NamedReading(key: key, name: name, value: Double(unsigned), rawBytes: nil, unit: unit, dataType: value.info.dataTypeString)
+                return NamedReading(key: key, name: name, value: Double(unsigned) * scale, rawBytes: nil, unit: unit, dataType: value.info.dataTypeString)
             case .bytes(let bytes):
                 return NamedReading(key: key, name: name, value: nil, rawBytes: bytes, unit: nil, dataType: value.info.dataTypeString)
             case nil:

--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -1288,7 +1288,7 @@ final class XPCService: NSObject, SMCtlDaemonXPCProtocol {
         }
     }
 
-    private static func userIsAdmin(_ uid: uid_t) -> Bool {
+    static func userIsAdmin(_ uid: uid_t) -> Bool {
         guard let admin = getgrnam("admin") else {
             return false
         }
@@ -1298,7 +1298,9 @@ final class XPCService: NSObject, SMCtlDaemonXPCProtocol {
 
         var count: Int32 = 64
         var groups = [gid_t](repeating: 0, count: Int(count))
-        let baseGroup = Int32(passwd.pointee.pw_gid)
+        // bitPattern: system accounts use "negative" ids (nobody's gid -2 is
+        // 4294967294 as gid_t); a checked Int32() conversion traps on them.
+        let baseGroup = Int32(bitPattern: passwd.pointee.pw_gid)
         let result = groups.withUnsafeMutableBufferPointer { buffer in
             getgrouplist(passwd.pointee.pw_name, baseGroup, buffer.baseAddress, &count)
         }

--- a/Sources/smctl/main.swift
+++ b/Sources/smctl/main.swift
@@ -117,6 +117,11 @@ struct Sensors: ParsableCommand {
 
         for reading in readings {
             if let value = reading.value {
+                // AC-W reports -1 when no adapter is attached.
+                if reading.key == "AC-W", value < 0 {
+                    print("  \(reading.name) (\(reading.key)): not connected")
+                    continue
+                }
                 let suffix = reading.unit.map { " \($0)" } ?? ""
                 print("  \(reading.name) (\(reading.key)): \(format(value, digits: 2))\(suffix)")
             } else if let rawBytes = reading.rawBytes {
@@ -392,6 +397,7 @@ private func printPower(_ snapshot: PowerSnapshot) {
     print("  Thermal pressure   \(snapshot.thermalPressure.rawValue)")
     print("  CPU throttling     \(throttleDescription(snapshot.cpu))")
     print("  Package power      \(watts(snapshot.packagePowerWatts))")
+    print("  System power       \(watts(snapshot.systemPowerWatts))")
     print("  Input              \(inputDescription(snapshot))")
 }
 

--- a/Tests/SMCCoreTests/SMCDataDecoderTests.swift
+++ b/Tests/SMCCoreTests/SMCDataDecoderTests.swift
@@ -25,4 +25,89 @@ final class SMCDataDecoderTests: XCTestCase {
         let decoded = try SMCDataDecoder.decode(key: "TC0P", bytes: [0x2a, 0x80], dataType: FourCharCode.unchecked("sp78"))
         XCTAssertEqual(decoded.doubleValue ?? 0, 42.5, accuracy: 0.001)
     }
+
+    func testDecodesSI8AdapterSentinel() throws {
+        // AC-W reads 0xff (-1) when no adapter is attached — observed on M2 MacBook Air.
+        let decoded = try SMCDataDecoder.decode(key: "AC-W", bytes: [0xff], dataType: FourCharCode.unchecked("si8 "))
+        XCTAssertEqual(decoded.doubleValue ?? 0, -1, accuracy: 0.001)
+    }
+
+    func testDecodesSI16LittleEndianBatteryCurrent() throws {
+        // B0AC raw [0xc0, 0xfe] observed on M2 MacBook Air while discharging at -320 mA.
+        let decoded = try SMCDataDecoder.decode(
+            key: "B0AC",
+            bytes: [0xc0, 0xfe],
+            dataType: FourCharCode.unchecked("si16"),
+            integerByteOrder: .little
+        )
+        XCTAssertEqual(decoded.doubleValue ?? 0, -320, accuracy: 0.001)
+    }
+
+    func testDecodesSI16BigEndian() throws {
+        let decoded = try SMCDataDecoder.decode(
+            key: "B0AC",
+            bytes: [0xfe, 0xc0],
+            dataType: FourCharCode.unchecked("si16"),
+            integerByteOrder: .big
+        )
+        XCTAssertEqual(decoded.doubleValue ?? 0, -320, accuracy: 0.001)
+    }
+
+    func testDecodesUI16LittleEndianBatteryVoltage() throws {
+        // B0AV raw [0xcf, 0x2f] observed on M2 MacBook Air: 12239 mV, matching
+        // the AppleSmartBattery IOKit voltage. Big-endian decodes to 53039.
+        let decoded = try SMCDataDecoder.decode(
+            key: "B0AV",
+            bytes: [0xcf, 0x2f],
+            dataType: FourCharCode.unchecked("ui16"),
+            integerByteOrder: .little
+        )
+        XCTAssertEqual(decoded.doubleValue ?? 0, 12239, accuracy: 0.001)
+    }
+
+    func testDecodesUI16BigEndian() throws {
+        let decoded = try SMCDataDecoder.decode(
+            key: "B0AV",
+            bytes: [0x2f, 0xcf],
+            dataType: FourCharCode.unchecked("ui16"),
+            integerByteOrder: .big
+        )
+        XCTAssertEqual(decoded.doubleValue ?? 0, 12239, accuracy: 0.001)
+    }
+
+    func testDecodesUI32BothByteOrders() throws {
+        let little = try SMCDataDecoder.decode(
+            key: "Test",
+            bytes: [0x78, 0x56, 0x34, 0x12],
+            dataType: FourCharCode.unchecked("ui32"),
+            integerByteOrder: .little
+        )
+        XCTAssertEqual(little.doubleValue ?? 0, Double(0x1234_5678), accuracy: 0.001)
+
+        let big = try SMCDataDecoder.decode(
+            key: "Test",
+            bytes: [0x12, 0x34, 0x56, 0x78],
+            dataType: FourCharCode.unchecked("ui32"),
+            integerByteOrder: .big
+        )
+        XCTAssertEqual(big.doubleValue ?? 0, Double(0x1234_5678), accuracy: 0.001)
+    }
+
+    func testDecodesSI32LittleEndianNegative() throws {
+        let decoded = try SMCDataDecoder.decode(
+            key: "Test",
+            bytes: [0xff, 0xff, 0xff, 0xff],
+            dataType: FourCharCode.unchecked("si32"),
+            integerByteOrder: .little
+        )
+        XCTAssertEqual(decoded.doubleValue ?? 0, -1, accuracy: 0.001)
+    }
+
+    func testPlatformByteOrderIsLittleEndianOnAppleSilicon() {
+        #if arch(arm64)
+        XCTAssertEqual(SMCIntegerByteOrder.platform, .little)
+        #else
+        XCTAssertEqual(SMCIntegerByteOrder.platform, .big)
+        #endif
+    }
 }

--- a/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
+++ b/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
@@ -293,6 +293,19 @@ final class SmctlDaemonTests: XCTestCase {
     }
 }
 
+final class XPCAuthorizationTests: XCTestCase {
+    func testUserIsAdminHandlesSystemAccountsWithNegativeIDs() {
+        // nobody is uid/gid -2 (4294967294 as uid_t). The group lookup must not
+        // trap converting such ids to Int32 — a non-admin caller crashing the
+        // daemon is a local DoS (regression test for a real crash).
+        XCTAssertFalse(XPCService.userIsAdmin(uid_t(bitPattern: -2)))
+    }
+
+    func testUserIsAdminReturnsFalseForUnknownUID() {
+        XCTAssertFalse(XPCService.userIsAdmin(54321))
+    }
+}
+
 final class AlertActionRunnerTests: XCTestCase {
     func testExecRunsSubprocessWithSubstitutedArgv() throws {
         let marker = NSTemporaryDirectory() + "smctl-alert-\(UUID().uuidString)"


### PR DESCRIPTION
## Summary

Two fixes, both found and verified on real hardware (M2 MacBook Air, macOS 15.7.5):

### 1. Integer SMC keys decoded wrong on Apple Silicon (`4453647`)

- **ui16/ui32 used big-endian** (Intel convention); Apple Silicon SMC is little-endian. B0AV read 53039 instead of 12239 mV (IOKit ground truth: 12235 mV). Byte order is now a decode parameter defaulting to the build architecture.
- **si8/si16/si32 were unsupported** and fell through to raw bytes. Not cosmetic: the daemon's plugged-in detection reads AC-W (si8) via `doubleValue`, which always returned nil and silently defaulted to plugged-in. Verified live: AC-W now tracks adapter attach/detach (-1 ↔ wattage), B0AC matches IOKit Amperage.
- B0AC/B0AV report mA/mV; values are now scaled to the displayed A/V units.
- **PDTR is DC-in total power** — legitimately ~0 on battery (verified: on AC it exactly equals VD0R x ID0R). Added PSTR (system total power) to `sensors` and `power status` as the portable-friendly draw signal.

### 2. Unauthorized XPC write crashed the daemon (`38dc9de`)

`userIsAdmin` converted the caller's primary gid with a checked `Int32()` init. System accounts use "negative" ids (nobody's gid -2 = 4294967294 as gid_t), so the conversion trapped — turning the authorization gate into a local DoS. Reproduced on-machine: `sudo -u nobody smctl battery maintain 50` crashed smctld; after the fix it gets a clean "Write requests require root or an admin user." with the daemon PID unchanged. Fixed with `Int32(bitPattern:)` + regression tests.

## Test plan

- [x] 11 new unit tests (decoder byte orders with real captured bytes; userIsAdmin with system-account ids) — CI runs them (local CLT has no XCTest)
- [x] Real-hardware verification on M2 MacBook Air against `ioreg`/`AppleSmartBattery`: voltage/current match within sampling noise
- [x] End-to-end battery maintain 70-80: charge inhibit at 80% (B0AC 1535 -> 0 mA), resume at limit 90 (-> +1547 mA), policy survives daemon restart
- [x] Hardware data point for the coverage list: M2 MacBook Air (Mac14,2) detects tahoe-charging/tahoe-adapter on macOS 15.7.5; charge control works. Note: with CHTE inhibit, pmset/ioreg still report "charging" — actual state is visible in B0AC.