### PR TITLE
feat(battery): manual toggles, maintain --force-discharge, time remaining, daemon logs

### DIFF
--- a/Sources/PolicyEngine/PolicyEngine.swift
+++ b/Sources/PolicyEngine/PolicyEngine.swift
@@ -100,11 +100,15 @@ public struct BatteryObservation: Codable, Equatable, Sendable {
     public var isChargingAllowed: Bool
     /// Whether wall power is present (AC-W).
     public var isPluggedIn: Bool
+    /// Whether the SMC currently allows adapter power input (CHIE / CH0I status).
+    /// nil when adapter control is unsupported or unreadable.
+    public var isAdapterEnabled: Bool?
 
-    public init(chargePercent: Int, isChargingAllowed: Bool, isPluggedIn: Bool = true) {
+    public init(chargePercent: Int, isChargingAllowed: Bool, isPluggedIn: Bool = true, isAdapterEnabled: Bool? = nil) {
         self.chargePercent = min(100, max(0, chargePercent))
         self.isChargingAllowed = isChargingAllowed
         self.isPluggedIn = isPluggedIn
+        self.isAdapterEnabled = isAdapterEnabled
     }
 
     /// Best available approximation of "actively charging": power present and charging allowed.
@@ -146,7 +150,8 @@ public struct ChargeStateMachine: Sendable {
     public mutating func evaluate(
         limit: ChargeLimit,
         observation: BatteryObservation,
-        now: Date
+        now: Date,
+        forceDischarge: Bool = false
     ) -> ChargeEvaluation {
         let slept = lastEvaluation.map { now.timeIntervalSince($0) > period * missedBeatMultiplier } ?? false
         lastEvaluation = now
@@ -182,6 +187,20 @@ public struct ChargeStateMachine: Sendable {
             actions.append(.setChargingEnabled(false))
         }
 
+        // Force-discharge: when enabled, the policy owns the adapter switch — cut
+        // adapter power while above the band so the battery drains down to it, and
+        // restore once inside. Acts only when the adapter state is readable, and
+        // never below the upper bound, so it cannot fight the charge dead-band.
+        // When disabled the policy never touches the adapter: a manual one-shot
+        // `discharge` owns it then.
+        if forceDischarge {
+            if effectiveObservation.chargePercent > limit.upperBound, effectiveObservation.isAdapterEnabled == true {
+                actions.append(.setAdapterEnabled(false))
+            } else if effectiveObservation.chargePercent <= limit.upperBound, effectiveObservation.isAdapterEnabled == false {
+                actions.append(.setAdapterEnabled(true))
+            }
+        }
+
         return ChargeEvaluation(
             actions: actions,
             sleptSinceLastEvaluation: slept,
@@ -193,9 +212,10 @@ public struct ChargeStateMachine: Sendable {
     public mutating func evaluate<C: PolicyClock>(
         limit: ChargeLimit,
         observation: BatteryObservation,
-        clock: C
+        clock: C,
+        forceDischarge: Bool = false
     ) -> ChargeEvaluation {
-        evaluate(limit: limit, observation: observation, now: clock.now)
+        evaluate(limit: limit, observation: observation, now: clock.now, forceDischarge: forceDischarge)
     }
 }
 

--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -72,11 +72,15 @@ struct BatteryConfig: Codable, Equatable, Sendable {
     var limit: String
     var sleep_policy: String
     var magsafe_led: Bool
+    /// When true, maintain actively discharges down to the band by cutting
+    /// adapter power while above the upper bound (unreliable in clamshell mode).
+    var force_discharge: Bool
 
-    init(limit: String = "100", sleep_policy: String = "strict", magsafe_led: Bool = true) {
+    init(limit: String = "100", sleep_policy: String = "strict", magsafe_led: Bool = true, force_discharge: Bool = false) {
         self.limit = limit
         self.sleep_policy = sleep_policy
         self.magsafe_led = magsafe_led
+        self.force_discharge = force_discharge
     }
 
     // Defensive decoding: missing keys fall back to defaults. Synthesized decoding
@@ -87,6 +91,7 @@ struct BatteryConfig: Codable, Equatable, Sendable {
         limit = try container.decodeIfPresent(String.self, forKey: .limit) ?? "100"
         sleep_policy = try container.decodeIfPresent(String.self, forKey: .sleep_policy) ?? "strict"
         magsafe_led = try container.decodeIfPresent(Bool.self, forKey: .magsafe_led) ?? true
+        force_discharge = try container.decodeIfPresent(Bool.self, forKey: .force_discharge) ?? false
     }
 }
 
@@ -376,18 +381,29 @@ public final class SmctlDaemon: @unchecked Sendable {
 
     func reloadConfig() {
         queue.sync {
+            let wasForcing = config.battery.force_discharge
             config = Self.loadConfig(path: configPath)
             let policy = (try? SleepPolicy.parse(config.battery.sleep_policy)) ?? .strict
             sleepMachine.setPolicy(policy)
+            if wasForcing, !config.battery.force_discharge, readAdapterEnabledLocked() == false {
+                try? applyAdapterLocked(true)
+            }
             evaluateLocked()
         }
     }
 
-    func setChargeLimit(_ limit: String) throws {
+    func setChargeLimit(_ limit: String, forceDischarge: Bool = false) throws {
         _ = try ChargeLimit.parse(limit)
         try queue.sync {
+            let wasForcing = config.battery.force_discharge
             config.battery.limit = limit
+            config.battery.force_discharge = forceDischarge
             try Self.writeConfig(config, path: configPath)
+            // Leaving force-discharge with the adapter cut would strand the Mac
+            // on battery; hand the adapter back before the policy stops owning it.
+            if wasForcing, !forceDischarge, readAdapterEnabledLocked() == false {
+                try? applyAdapterLocked(true)
+            }
             evaluateLocked()
         }
     }
@@ -521,7 +537,12 @@ public final class SmctlDaemon: @unchecked Sendable {
         }
         let now = Date()
         let limit = currentChargeLimitLocked()
-        let evaluation = chargeMachine.evaluate(limit: limit, observation: observation, now: now)
+        let evaluation = chargeMachine.evaluate(
+            limit: limit,
+            observation: observation,
+            now: now,
+            forceDischarge: config.battery.force_discharge
+        )
         do {
             try applyActionsLocked(evaluation.actions)
             lastEvaluation = now
@@ -547,12 +568,20 @@ public final class SmctlDaemon: @unchecked Sendable {
         return BatteryObservation(
             chargePercent: Int(charge.rounded()),
             isChargingAllowed: chargingAllowed,
-            isPluggedIn: pluggedIn
+            isPluggedIn: pluggedIn,
+            isAdapterEnabled: readAdapterEnabledLocked()
         )
     }
 
     private func readChargingEnabledLocked() -> Bool? {
         guard let group = capabilities.chargingControl, let value = try? backend?.readValue(group.statusKey) else {
+            return nil
+        }
+        return value.bytes.allSatisfy { $0 == 0 }
+    }
+
+    private func readAdapterEnabledLocked() -> Bool? {
+        guard let group = capabilities.adapterControl, let value = try? backend?.readValue(group.statusKey) else {
             return nil
         }
         return value.bytes.allSatisfy { $0 == 0 }
@@ -980,6 +1009,7 @@ public final class SmctlDaemon: @unchecked Sendable {
             statusMessage = nil
         }
 
+        let timeEstimate = PowerSourceTimeEstimate.read()
         return BatteryStatusDTO(
             timestamp: Date(),
             chargePercent: observation?.chargePercent,
@@ -993,7 +1023,10 @@ public final class SmctlDaemon: @unchecked Sendable {
             lowerBound: limit.lowerBound,
             upperBound: limit.upperBound,
             sleepPolicy: sleepMachine.policy.rawValue,
-            message: statusMessage
+            message: statusMessage,
+            timeToEmptyMinutes: timeEstimate.toEmpty,
+            timeToFullMinutes: timeEstimate.toFull,
+            forceDischarge: config.battery.force_discharge
         )
     }
 
@@ -1214,7 +1247,7 @@ final class XPCService: NSObject, SMCtlDaemonXPCProtocol {
     func setChargeLimit(_ requestData: Data, withReply reply: @escaping (Data?, String?) -> Void) {
         doWrite(reply) {
             let request = try SMCtlProtocolCoding.decode(SetChargeLimitRequestDTO.self, from: requestData)
-            try daemon.setChargeLimit(request.limit)
+            try daemon.setChargeLimit(request.limit, forceDischarge: request.forceDischarge ?? false)
         }
     }
 

--- a/Sources/SMCtlDaemonCore/PowerSourceTimeEstimate.swift
+++ b/Sources/SMCtlDaemonCore/PowerSourceTimeEstimate.swift
@@ -1,0 +1,32 @@
+import Foundation
+import IOKit.ps
+
+/// Time-remaining estimates from IOKit power sources. These come from the OS
+/// gauge (not the SMC), so they live here as presentation data for battery
+/// status rather than in SMCCore.
+enum PowerSourceTimeEstimate {
+    /// Minutes to empty (discharging) and to full (charging) for the internal
+    /// battery. IOKit reports -1 while still calculating; that and missing
+    /// keys both map to nil.
+    static func read() -> (toEmpty: Int?, toFull: Int?) {
+        guard
+            let blob = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+            let list = IOPSCopyPowerSourcesList(blob)?.takeRetainedValue() as? [CFTypeRef]
+        else {
+            return (nil, nil)
+        }
+
+        for source in list {
+            guard
+                let description = IOPSGetPowerSourceDescription(blob, source)?.takeUnretainedValue() as? [String: Any],
+                description[kIOPSTypeKey] as? String == kIOPSInternalBatteryType
+            else {
+                continue
+            }
+            let toEmpty = (description[kIOPSTimeToEmptyKey] as? Int).flatMap { $0 > 0 ? $0 : nil }
+            let toFull = (description[kIOPSTimeToFullChargeKey] as? Int).flatMap { $0 > 0 ? $0 : nil }
+            return (toEmpty, toFull)
+        }
+        return (nil, nil)
+    }
+}

--- a/Sources/SMCtlProtocol/SMCtlProtocol.swift
+++ b/Sources/SMCtlProtocol/SMCtlProtocol.swift
@@ -91,6 +91,12 @@ public struct BatteryStatusDTO: Codable, Equatable, Sendable {
     public var upperBound: Int
     public var sleepPolicy: String
     public var message: String?
+    /// IOKit power-source estimates in minutes; nil when unknown, still
+    /// calculating, or talking to an older daemon (missing keys decode to nil).
+    public var timeToEmptyMinutes: Int?
+    public var timeToFullMinutes: Int?
+    /// Whether maintain actively discharges down to the band (nil from older daemons).
+    public var forceDischarge: Bool?
 
     public init(
         timestamp: Date,
@@ -105,7 +111,10 @@ public struct BatteryStatusDTO: Codable, Equatable, Sendable {
         lowerBound: Int,
         upperBound: Int,
         sleepPolicy: String,
-        message: String?
+        message: String?,
+        timeToEmptyMinutes: Int? = nil,
+        timeToFullMinutes: Int? = nil,
+        forceDischarge: Bool? = nil
     ) {
         self.timestamp = timestamp
         self.chargePercent = chargePercent
@@ -120,6 +129,9 @@ public struct BatteryStatusDTO: Codable, Equatable, Sendable {
         self.upperBound = upperBound
         self.sleepPolicy = sleepPolicy
         self.message = message
+        self.timeToEmptyMinutes = timeToEmptyMinutes
+        self.timeToFullMinutes = timeToFullMinutes
+        self.forceDischarge = forceDischarge
     }
 }
 
@@ -178,9 +190,13 @@ public struct DaemonStatusDTO: Codable, Equatable, Sendable {
 
 public struct SetChargeLimitRequestDTO: Codable, Equatable, Sendable {
     public var limit: String
+    /// Actively discharge down to the band by cutting adapter power while above
+    /// the upper bound. Optional so requests from older CLIs decode to nil (off).
+    public var forceDischarge: Bool?
 
-    public init(limit: String) {
+    public init(limit: String, forceDischarge: Bool? = nil) {
         self.limit = limit
+        self.forceDischarge = forceDischarge
     }
 }
 

--- a/Sources/smctl/main.swift
+++ b/Sources/smctl/main.swift
@@ -238,7 +238,7 @@ struct Battery: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "battery",
         abstract: "Inspect and control battery charge policy through smctld.",
-        subcommands: [BatteryStatus.self, Maintain.self, Charge.self, Discharge.self]
+        subcommands: [BatteryStatus.self, Maintain.self, Charge.self, Discharge.self, Charging.self, Adapter.self]
     )
 }
 
@@ -264,14 +264,19 @@ struct Maintain: ParsableCommand {
     @Argument(help: "Charge limit: 80, 70-80, or stop.")
     var limit: String
 
+    @Flag(name: .long, help: "Actively discharge down to the limit by cutting adapter power while above it (unreliable in clamshell mode).")
+    var forceDischarge = false
+
     func run() throws {
         let client = DaemonClient()
         let normalized = limit.lowercased() == "stop" ? "100" : limit
-        try client.setChargeLimit(normalized)
+        try client.setChargeLimit(normalized, forceDischarge: forceDischarge)
         if normalized == "100" {
             _ = try? client.setChargingEnabled(true)
             _ = try? client.setAdapterEnabled(true)
             print("Battery charge limiting stopped; charging and adapter power were restored when supported.")
+        } else if forceDischarge {
+            print("Battery maintain policy set to \(limit) with force-discharge: adapter power is cut while above the limit.")
         } else {
             print("Battery maintain policy set to \(limit).")
         }
@@ -293,6 +298,54 @@ struct Charge: ParsableCommand {
         _ = try? client.setAdapterEnabled(true)
         try client.setChargingEnabled(true)
         print("Charging enabled with upper target \(target)%.")
+    }
+}
+
+struct Charging: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "charging", abstract: "Manually allow or block battery charging.")
+
+    @Argument(help: "on or off.")
+    var setting: String
+
+    func run() throws {
+        let enabled = try parseOnOff(setting)
+        let client = DaemonClient()
+        try client.setChargingEnabled(enabled)
+        print("Charging \(enabled ? "enabled" : "disabled").")
+        // A maintain policy re-evaluates every few seconds and will overwrite a
+        // manual toggle that disagrees with it — warn instead of silently losing.
+        if let status: BatteryStatusDTO = try? client.getBatteryStatus(), status.upperBound < 100 {
+            print("Note: maintain \(status.configuredLimit) is active and may override this on its next evaluation. Use 'smctl battery maintain stop' first for manual control.")
+        }
+    }
+}
+
+struct Adapter: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "adapter", abstract: "Manually enable or cut adapter power input.")
+
+    @Argument(help: "on or off.")
+    var setting: String
+
+    func run() throws {
+        let enabled = try parseOnOff(setting)
+        let client = DaemonClient()
+        try client.setAdapterEnabled(enabled)
+        if enabled {
+            print("Adapter power enabled.")
+        } else {
+            print("Adapter power cut: the Mac now runs on battery even while plugged in. Restore with 'smctl battery adapter on'.")
+        }
+    }
+}
+
+private func parseOnOff(_ setting: String) throws -> Bool {
+    switch setting.lowercased() {
+    case "on":
+        return true
+    case "off":
+        return false
+    default:
+        throw ValidationError("Expected 'on' or 'off', got '\(setting)'.")
     }
 }
 
@@ -344,6 +397,10 @@ struct Discharge: ParsableCommand {
                 print("Target reached; restoring adapter power.")
                 return
             }
+            // Re-assert the cut every poll: SMC firmware can silently re-enable
+            // adapter power (observed on M2 when the charging-enable key is
+            // written while a cut is active), which would stall the discharge.
+            try client.setAdapterEnabled(false)
         }
     }
 }
@@ -571,7 +628,7 @@ struct Daemon: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "daemon",
         abstract: "Install, remove, and inspect smctld.",
-        subcommands: [DaemonInstall.self, DaemonUninstall.self, DaemonRestart.self, DaemonStatus.self, DaemonPing.self]
+        subcommands: [DaemonInstall.self, DaemonUninstall.self, DaemonRestart.self, DaemonStatus.self, DaemonPing.self, DaemonLogs.self]
     )
 }
 
@@ -620,6 +677,30 @@ struct DaemonStatus: ParsableCommand {
 
     private func format(_ value: Double) -> String {
         String(format: "%.0f", value)
+    }
+}
+
+struct DaemonLogs: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "logs", abstract: "Show recent smctld log messages (wraps `log show`).")
+
+    @Option(name: .long, help: "How far back to look, e.g. 10m, 1h, 2d.")
+    var last: String = "1h"
+
+    func run() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        process.arguments = [
+            "show",
+            "--last", last,
+            "--predicate", "subsystem == \"one.leaper.smctl\"",
+            "--style", "compact",
+            "--info"
+        ]
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw ValidationError("log show exited with status \(process.terminationStatus); check the --last value (e.g. 10m, 1h, 2d).")
+        }
     }
 }
 
@@ -717,13 +798,23 @@ private func printBatteryStatus(_ status: BatteryStatusDTO) {
     }
     print("  charging: \(status.isCharging.map { $0 ? "enabled" : "disabled" } ?? "unknown")")
     print("  plugged in: \(status.pluggedIn.map { $0 ? "yes" : "no" } ?? "unknown")")
-    print("  maintain: \(status.configuredLimit) (lower \(status.lowerBound)%, upper \(status.upperBound)%)")
+    if let minutes = status.timeToFullMinutes {
+        print("  time to full: \(hoursMinutes(minutes))")
+    } else if let minutes = status.timeToEmptyMinutes {
+        print("  time remaining: \(hoursMinutes(minutes))")
+    }
+    let forceSuffix = status.forceDischarge == true ? ", force-discharge" : ""
+    print("  maintain: \(status.configuredLimit) (lower \(status.lowerBound)%, upper \(status.upperBound)%\(forceSuffix))")
     print("  sleep policy: \(status.sleepPolicy)")
     print("  charging control: \(status.chargingControlGroup ?? "unsupported")")
     print("  adapter control: \(status.adapterControlGroup ?? "unsupported")")
     if let message = status.message {
         print("  note: \(message)")
     }
+}
+
+private func hoursMinutes(_ minutes: Int) -> String {
+    minutes < 60 ? "\(minutes)m" : "\(minutes / 60)h \(minutes % 60)m"
 }
 
 private func printFansStatus(_ status: FansStatusDTO) {
@@ -894,8 +985,8 @@ private final class DaemonClient {
         }
     }
 
-    func setChargeLimit(_ limit: String) throws {
-        let data = try SMCtlProtocolCoding.encode(SetChargeLimitRequestDTO(limit: limit))
+    func setChargeLimit(_ limit: String, forceDischarge: Bool = false) throws {
+        let data = try SMCtlProtocolCoding.encode(SetChargeLimitRequestDTO(limit: limit, forceDischarge: forceDischarge))
         let _: EmptyResponseDTO = try call { proxy, reply in
             proxy.setChargeLimit(data, withReply: reply)
         }

--- a/Tests/PolicyEngineTests/ChargeStateMachineTests.swift
+++ b/Tests/PolicyEngineTests/ChargeStateMachineTests.swift
@@ -100,11 +100,58 @@ final class ChargeStateMachineTests: XCTestCase {
         XCTAssertEqual(try ChargeLimit.parse("stop"), .disabled)
     }
 
+    func testForceDischargeCutsAdapterAboveBandAndRestoresInside() {
+        let limit = ChargeLimit(upperBound: 60, lowerDelta: 2)
+        let now = Date()
+
+        // Above the band with adapter on: cut it (plus the regular charge disable
+        // is already latched here, chargingAllowed: false).
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 80, chargingAllowed: false, adapterEnabled: true, forceDischarge: true, now: now),
+            [.setAdapterEnabled(false)]
+        )
+        // Still above: adapter already cut, nothing to do.
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 70, chargingAllowed: false, adapterEnabled: false, forceDischarge: true, now: now),
+            []
+        )
+        // Reached the upper bound: hand the adapter back.
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 60, chargingAllowed: false, adapterEnabled: false, forceDischarge: true, now: now),
+            [.setAdapterEnabled(true)]
+        )
+        // Inside the band with adapter on: steady state.
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 59, chargingAllowed: false, adapterEnabled: true, forceDischarge: true, now: now),
+            []
+        )
+    }
+
+    func testForceDischargeDoesNothingWhenAdapterStateUnknown() {
+        let limit = ChargeLimit(upperBound: 60, lowerDelta: 2)
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 80, chargingAllowed: false, adapterEnabled: nil, forceDischarge: true, now: Date()),
+            []
+        )
+    }
+
+    func testWithoutForceDischargeThePolicyNeverTouchesTheAdapter() {
+        // A manual one-shot `discharge` owns the adapter then; the maintain loop
+        // re-enabling it would break the discharge mid-flight.
+        let limit = ChargeLimit(upperBound: 60, lowerDelta: 2)
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 80, chargingAllowed: false, adapterEnabled: false, forceDischarge: false, now: Date()),
+            []
+        )
+    }
+
     private func evaluate(
         limit: ChargeLimit,
         percent: Int,
         chargingAllowed: Bool,
         pluggedIn: Bool = true,
+        adapterEnabled: Bool? = nil,
+        forceDischarge: Bool = false,
         now: Date
     ) -> [BatteryPolicyAction] {
         var machine = ChargeStateMachine(period: 10)
@@ -113,9 +160,11 @@ final class ChargeStateMachineTests: XCTestCase {
             observation: BatteryObservation(
                 chargePercent: percent,
                 isChargingAllowed: chargingAllowed,
-                isPluggedIn: pluggedIn
+                isPluggedIn: pluggedIn,
+                isAdapterEnabled: adapterEnabled
             ),
-            now: now
+            now: now,
+            forceDischarge: forceDischarge
         ).actions
     }
 }


### PR DESCRIPTION
Stacked on #4 (base = `fix/apple-silicon-integer-decode`); rebase onto main after #4 merges.

Feature parity pass against actuallymentor/battery v1.3.2 — see the commit message for the full list. Highlights:

- **`battery maintain N --force-discharge`** — the maintain policy actively discharges down to the band by cutting adapter power (CHIE), restores it once inside, and is **self-healing**: the evaluation loop re-asserts the cut every period.
- **Field finding**: writing CHTE (charging enable) while a CHIE cut is active makes the SMC silently re-enable adapter power. Observed live on M2 — it permanently stalled a one-shot `battery discharge` at 79%. Both discharge paths now survive it (verified by deliberately triggering the reset under force-discharge).
- `battery charging|adapter on|off`, time-to-empty/full in `battery status`, `daemon logs --last 1h`.

## Test plan
- [x] 3 new PolicyEngine transition-matrix tests (CI; local CLT lacks XCTest)
- [x] Live on M2 Air: cut on entry (CHIE 00→08 within 15 s), discharge at -0.34 A, self-heal vs deliberate CHTE trigger, adapter restored on force→plain transition (both directions), status/JSON surfacing, maintain-override warning verified truthful
- [x] Currently discharging 79% → 60% under force-discharge on the test machine; 10-min monitor logging the full curve