### PR TITLE
feat(battery): add force-discharge and manual toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ $ smctl sensors --watch            # live temperatures, fan RPM, package power
 | Command | What it does |
 |---|---|
 | `smctl sensors [--watch] [--json]` | Temperatures by sensor group, fan RPM/mode, battery, package power |
-| `smctl battery status` | Charge level, charging state, configured limit |
-| `smctl battery maintain 80` / `70-80` / `stop` | Charge limit with dead-band (no charge/discharge flapping) |
+| `smctl battery status` | Charge level, charging state, configured limit, time estimate |
+| `smctl battery maintain 80` / `70-80` / `stop` | Charge limit with dead-band; add `--force-discharge` to drain down to the band |
+| `smctl battery charging on\|off` / `adapter on\|off` | Manual charging and adapter-power toggles |
 | `smctl battery charge 90` / `discharge 40` | One-shot top-up or supervised discharge |
 | `smctl fan status` | Per-fan actual/target/min/max RPM and control mode |
 | `smctl fan set 2500 [--fan N]` | Manual fan target |
 | `smctl fan profile quiet\|full\|auto\|<custom>` | Declarative fan curves (TOML), hysteresis + slew-rate limited |
 | `smctl power status [--watch] [--json]` | Thermal pressure, CPU throttling (% speed limit), system/package + input power |
 | `smctl alert list\|status\|test <name>` | Temperature/event alerts → webhook, command, or log (configured in TOML) |
-| `smctl daemon install\|uninstall\|status\|ping` | Manage the privileged helper |
+| `smctl daemon install\|uninstall\|status\|ping\|logs` | Manage the privileged helper and inspect recent daemon logs |
 
 Policies live in `/etc/smctl/config.toml` — declarative, diffable, dotfiles-friendly.
 

--- a/Sources/PolicyEngine/PolicyEngine.swift
+++ b/Sources/PolicyEngine/PolicyEngine.swift
@@ -100,11 +100,15 @@ public struct BatteryObservation: Codable, Equatable, Sendable {
     public var isChargingAllowed: Bool
     /// Whether wall power is present (AC-W).
     public var isPluggedIn: Bool
+    /// Whether the SMC currently allows adapter power input (CHIE / CH0I status).
+    /// nil when adapter control is unsupported or unreadable.
+    public var isAdapterEnabled: Bool?
 
-    public init(chargePercent: Int, isChargingAllowed: Bool, isPluggedIn: Bool = true) {
+    public init(chargePercent: Int, isChargingAllowed: Bool, isPluggedIn: Bool = true, isAdapterEnabled: Bool? = nil) {
         self.chargePercent = min(100, max(0, chargePercent))
         self.isChargingAllowed = isChargingAllowed
         self.isPluggedIn = isPluggedIn
+        self.isAdapterEnabled = isAdapterEnabled
     }
 
     /// Best available approximation of "actively charging": power present and charging allowed.
@@ -146,7 +150,8 @@ public struct ChargeStateMachine: Sendable {
     public mutating func evaluate(
         limit: ChargeLimit,
         observation: BatteryObservation,
-        now: Date
+        now: Date,
+        forceDischarge: Bool = false
     ) -> ChargeEvaluation {
         let slept = lastEvaluation.map { now.timeIntervalSince($0) > period * missedBeatMultiplier } ?? false
         lastEvaluation = now
@@ -182,6 +187,20 @@ public struct ChargeStateMachine: Sendable {
             actions.append(.setChargingEnabled(false))
         }
 
+        // Force-discharge: when enabled, the policy owns the adapter switch — cut
+        // adapter power while above the band so the battery drains down to it, and
+        // restore once inside. Acts only when the adapter state is readable, and
+        // never below the upper bound, so it cannot fight the charge dead-band.
+        // When disabled the policy never touches the adapter: a manual one-shot
+        // `discharge` owns it then.
+        if forceDischarge {
+            if effectiveObservation.chargePercent > limit.upperBound, effectiveObservation.isAdapterEnabled == true {
+                actions.append(.setAdapterEnabled(false))
+            } else if effectiveObservation.chargePercent <= limit.upperBound, effectiveObservation.isAdapterEnabled == false {
+                actions.append(.setAdapterEnabled(true))
+            }
+        }
+
         return ChargeEvaluation(
             actions: actions,
             sleptSinceLastEvaluation: slept,
@@ -193,9 +212,10 @@ public struct ChargeStateMachine: Sendable {
     public mutating func evaluate<C: PolicyClock>(
         limit: ChargeLimit,
         observation: BatteryObservation,
-        clock: C
+        clock: C,
+        forceDischarge: Bool = false
     ) -> ChargeEvaluation {
-        evaluate(limit: limit, observation: observation, now: clock.now)
+        evaluate(limit: limit, observation: observation, now: clock.now, forceDischarge: forceDischarge)
     }
 }
 

--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -72,11 +72,15 @@ struct BatteryConfig: Codable, Equatable, Sendable {
     var limit: String
     var sleep_policy: String
     var magsafe_led: Bool
+    /// When true, maintain actively discharges down to the band by cutting
+    /// adapter power while above the upper bound (unreliable in clamshell mode).
+    var force_discharge: Bool
 
-    init(limit: String = "100", sleep_policy: String = "strict", magsafe_led: Bool = true) {
+    init(limit: String = "100", sleep_policy: String = "strict", magsafe_led: Bool = true, force_discharge: Bool = false) {
         self.limit = limit
         self.sleep_policy = sleep_policy
         self.magsafe_led = magsafe_led
+        self.force_discharge = force_discharge
     }
 
     // Defensive decoding: missing keys fall back to defaults. Synthesized decoding
@@ -87,6 +91,7 @@ struct BatteryConfig: Codable, Equatable, Sendable {
         limit = try container.decodeIfPresent(String.self, forKey: .limit) ?? "100"
         sleep_policy = try container.decodeIfPresent(String.self, forKey: .sleep_policy) ?? "strict"
         magsafe_led = try container.decodeIfPresent(Bool.self, forKey: .magsafe_led) ?? true
+        force_discharge = try container.decodeIfPresent(Bool.self, forKey: .force_discharge) ?? false
     }
 }
 
@@ -376,18 +381,30 @@ public final class SmctlDaemon: @unchecked Sendable {
 
     func reloadConfig() {
         queue.sync {
+            let wasForcing = config.battery.force_discharge
             config = Self.loadConfig(path: configPath)
             let policy = (try? SleepPolicy.parse(config.battery.sleep_policy)) ?? .strict
             sleepMachine.setPolicy(policy)
+            if wasForcing, !config.battery.force_discharge, readAdapterEnabledLocked() == false {
+                try? applyAdapterLocked(true)
+            }
             evaluateLocked()
         }
     }
 
-    func setChargeLimit(_ limit: String) throws {
-        _ = try ChargeLimit.parse(limit)
+    func setChargeLimit(_ limit: String, forceDischarge: Bool = false) throws {
+        let parsedLimit = try ChargeLimit.parse(limit)
+        let effectiveForceDischarge = parsedLimit.isLimiting && forceDischarge
         try queue.sync {
+            let wasForcing = config.battery.force_discharge
             config.battery.limit = limit
+            config.battery.force_discharge = effectiveForceDischarge
             try Self.writeConfig(config, path: configPath)
+            // Leaving force-discharge with the adapter cut would strand the Mac
+            // on battery; hand the adapter back before the policy stops owning it.
+            if wasForcing, !effectiveForceDischarge, readAdapterEnabledLocked() == false {
+                try? applyAdapterLocked(true)
+            }
             evaluateLocked()
         }
     }
@@ -521,7 +538,12 @@ public final class SmctlDaemon: @unchecked Sendable {
         }
         let now = Date()
         let limit = currentChargeLimitLocked()
-        let evaluation = chargeMachine.evaluate(limit: limit, observation: observation, now: now)
+        let evaluation = chargeMachine.evaluate(
+            limit: limit,
+            observation: observation,
+            now: now,
+            forceDischarge: config.battery.force_discharge
+        )
         do {
             try applyActionsLocked(evaluation.actions)
             lastEvaluation = now
@@ -547,12 +569,20 @@ public final class SmctlDaemon: @unchecked Sendable {
         return BatteryObservation(
             chargePercent: Int(charge.rounded()),
             isChargingAllowed: chargingAllowed,
-            isPluggedIn: pluggedIn
+            isPluggedIn: pluggedIn,
+            isAdapterEnabled: readAdapterEnabledLocked()
         )
     }
 
     private func readChargingEnabledLocked() -> Bool? {
         guard let group = capabilities.chargingControl, let value = try? backend?.readValue(group.statusKey) else {
+            return nil
+        }
+        return value.bytes.allSatisfy { $0 == 0 }
+    }
+
+    private func readAdapterEnabledLocked() -> Bool? {
+        guard let group = capabilities.adapterControl, let value = try? backend?.readValue(group.statusKey) else {
             return nil
         }
         return value.bytes.allSatisfy { $0 == 0 }
@@ -980,6 +1010,7 @@ public final class SmctlDaemon: @unchecked Sendable {
             statusMessage = nil
         }
 
+        let timeEstimate = PowerSourceTimeEstimate.read()
         return BatteryStatusDTO(
             timestamp: Date(),
             chargePercent: observation?.chargePercent,
@@ -993,7 +1024,10 @@ public final class SmctlDaemon: @unchecked Sendable {
             lowerBound: limit.lowerBound,
             upperBound: limit.upperBound,
             sleepPolicy: sleepMachine.policy.rawValue,
-            message: statusMessage
+            message: statusMessage,
+            timeToEmptyMinutes: timeEstimate.toEmpty,
+            timeToFullMinutes: timeEstimate.toFull,
+            forceDischarge: config.battery.force_discharge
         )
     }
 
@@ -1064,6 +1098,7 @@ public final class SmctlDaemon: @unchecked Sendable {
         limit = "\(config.battery.limit)"
         sleep_policy = "\(config.battery.sleep_policy)"
         magsafe_led = \(config.battery.magsafe_led ? "true" : "false")
+        force_discharge = \(config.battery.force_discharge ? "true" : "false")
 
         [fan]
         profile = "\(config.fan.profile)"
@@ -1214,7 +1249,7 @@ final class XPCService: NSObject, SMCtlDaemonXPCProtocol {
     func setChargeLimit(_ requestData: Data, withReply reply: @escaping (Data?, String?) -> Void) {
         doWrite(reply) {
             let request = try SMCtlProtocolCoding.decode(SetChargeLimitRequestDTO.self, from: requestData)
-            try daemon.setChargeLimit(request.limit)
+            try daemon.setChargeLimit(request.limit, forceDischarge: request.forceDischarge ?? false)
         }
     }
 

--- a/Sources/SMCtlDaemonCore/PowerSourceTimeEstimate.swift
+++ b/Sources/SMCtlDaemonCore/PowerSourceTimeEstimate.swift
@@ -1,0 +1,32 @@
+import Foundation
+import IOKit.ps
+
+/// Time-remaining estimates from IOKit power sources. These come from the OS
+/// gauge (not the SMC), so they live here as presentation data for battery
+/// status rather than in SMCCore.
+enum PowerSourceTimeEstimate {
+    /// Minutes to empty (discharging) and to full (charging) for the internal
+    /// battery. IOKit reports -1 while still calculating; that and missing
+    /// keys both map to nil.
+    static func read() -> (toEmpty: Int?, toFull: Int?) {
+        guard
+            let blob = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+            let list = IOPSCopyPowerSourcesList(blob)?.takeRetainedValue() as? [CFTypeRef]
+        else {
+            return (nil, nil)
+        }
+
+        for source in list {
+            guard
+                let description = IOPSGetPowerSourceDescription(blob, source)?.takeUnretainedValue() as? [String: Any],
+                description[kIOPSTypeKey] as? String == kIOPSInternalBatteryType
+            else {
+                continue
+            }
+            let toEmpty = (description[kIOPSTimeToEmptyKey] as? Int).flatMap { $0 > 0 ? $0 : nil }
+            let toFull = (description[kIOPSTimeToFullChargeKey] as? Int).flatMap { $0 > 0 ? $0 : nil }
+            return (toEmpty, toFull)
+        }
+        return (nil, nil)
+    }
+}

--- a/Sources/SMCtlProtocol/SMCtlProtocol.swift
+++ b/Sources/SMCtlProtocol/SMCtlProtocol.swift
@@ -91,6 +91,12 @@ public struct BatteryStatusDTO: Codable, Equatable, Sendable {
     public var upperBound: Int
     public var sleepPolicy: String
     public var message: String?
+    /// IOKit power-source estimates in minutes; nil when unknown, still
+    /// calculating, or talking to an older daemon (missing keys decode to nil).
+    public var timeToEmptyMinutes: Int?
+    public var timeToFullMinutes: Int?
+    /// Whether maintain actively discharges down to the band (nil from older daemons).
+    public var forceDischarge: Bool?
 
     public init(
         timestamp: Date,
@@ -105,7 +111,10 @@ public struct BatteryStatusDTO: Codable, Equatable, Sendable {
         lowerBound: Int,
         upperBound: Int,
         sleepPolicy: String,
-        message: String?
+        message: String?,
+        timeToEmptyMinutes: Int? = nil,
+        timeToFullMinutes: Int? = nil,
+        forceDischarge: Bool? = nil
     ) {
         self.timestamp = timestamp
         self.chargePercent = chargePercent
@@ -120,6 +129,9 @@ public struct BatteryStatusDTO: Codable, Equatable, Sendable {
         self.upperBound = upperBound
         self.sleepPolicy = sleepPolicy
         self.message = message
+        self.timeToEmptyMinutes = timeToEmptyMinutes
+        self.timeToFullMinutes = timeToFullMinutes
+        self.forceDischarge = forceDischarge
     }
 }
 
@@ -178,9 +190,13 @@ public struct DaemonStatusDTO: Codable, Equatable, Sendable {
 
 public struct SetChargeLimitRequestDTO: Codable, Equatable, Sendable {
     public var limit: String
+    /// Actively discharge down to the band by cutting adapter power while above
+    /// the upper bound. Optional so requests from older CLIs decode to nil (off).
+    public var forceDischarge: Bool?
 
-    public init(limit: String) {
+    public init(limit: String, forceDischarge: Bool? = nil) {
         self.limit = limit
+        self.forceDischarge = forceDischarge
     }
 }
 

--- a/Sources/smctl/main.swift
+++ b/Sources/smctl/main.swift
@@ -238,7 +238,7 @@ struct Battery: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "battery",
         abstract: "Inspect and control battery charge policy through smctld.",
-        subcommands: [BatteryStatus.self, Maintain.self, Charge.self, Discharge.self]
+        subcommands: [BatteryStatus.self, Maintain.self, Charge.self, Discharge.self, Charging.self, Adapter.self]
     )
 }
 
@@ -264,14 +264,22 @@ struct Maintain: ParsableCommand {
     @Argument(help: "Charge limit: 80, 70-80, or stop.")
     var limit: String
 
+    @Flag(name: .long, help: "Actively discharge down to the limit by cutting adapter power while above it (unreliable in clamshell mode).")
+    var forceDischarge = false
+
     func run() throws {
         let client = DaemonClient()
-        let normalized = limit.lowercased() == "stop" ? "100" : limit
-        try client.setChargeLimit(normalized)
+        let trimmed = limit.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let isStopping = ["stop", "off", "disabled", "100"].contains(trimmed)
+        let normalized = isStopping ? "100" : limit
+        let effectiveForceDischarge = !isStopping && forceDischarge
+        try client.setChargeLimit(normalized, forceDischarge: effectiveForceDischarge)
         if normalized == "100" {
             _ = try? client.setChargingEnabled(true)
             _ = try? client.setAdapterEnabled(true)
             print("Battery charge limiting stopped; charging and adapter power were restored when supported.")
+        } else if effectiveForceDischarge {
+            print("Battery maintain policy set to \(limit) with force-discharge: adapter power is cut while above the limit.")
         } else {
             print("Battery maintain policy set to \(limit).")
         }
@@ -293,6 +301,54 @@ struct Charge: ParsableCommand {
         _ = try? client.setAdapterEnabled(true)
         try client.setChargingEnabled(true)
         print("Charging enabled with upper target \(target)%.")
+    }
+}
+
+struct Charging: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "charging", abstract: "Manually allow or block battery charging.")
+
+    @Argument(help: "on or off.")
+    var setting: String
+
+    func run() throws {
+        let enabled = try parseOnOff(setting)
+        let client = DaemonClient()
+        try client.setChargingEnabled(enabled)
+        print("Charging \(enabled ? "enabled" : "disabled").")
+        // A maintain policy re-evaluates every few seconds and will overwrite a
+        // manual toggle that disagrees with it — warn instead of silently losing.
+        if let status: BatteryStatusDTO = try? client.getBatteryStatus(), status.upperBound < 100 {
+            print("Note: maintain \(status.configuredLimit) is active and may override this on its next evaluation. Use 'smctl battery maintain stop' first for manual control.")
+        }
+    }
+}
+
+struct Adapter: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "adapter", abstract: "Manually enable or cut adapter power input.")
+
+    @Argument(help: "on or off.")
+    var setting: String
+
+    func run() throws {
+        let enabled = try parseOnOff(setting)
+        let client = DaemonClient()
+        try client.setAdapterEnabled(enabled)
+        if enabled {
+            print("Adapter power enabled.")
+        } else {
+            print("Adapter power cut: the Mac now runs on battery even while plugged in. Restore with 'smctl battery adapter on'.")
+        }
+    }
+}
+
+private func parseOnOff(_ setting: String) throws -> Bool {
+    switch setting.lowercased() {
+    case "on":
+        return true
+    case "off":
+        return false
+    default:
+        throw ValidationError("Expected 'on' or 'off', got '\(setting)'.")
     }
 }
 
@@ -344,6 +400,10 @@ struct Discharge: ParsableCommand {
                 print("Target reached; restoring adapter power.")
                 return
             }
+            // Re-assert the cut every poll: SMC firmware can silently re-enable
+            // adapter power (observed on M2 when the charging-enable key is
+            // written while a cut is active), which would stall the discharge.
+            try client.setAdapterEnabled(false)
         }
     }
 }
@@ -571,7 +631,7 @@ struct Daemon: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "daemon",
         abstract: "Install, remove, and inspect smctld.",
-        subcommands: [DaemonInstall.self, DaemonUninstall.self, DaemonRestart.self, DaemonStatus.self, DaemonPing.self]
+        subcommands: [DaemonInstall.self, DaemonUninstall.self, DaemonRestart.self, DaemonStatus.self, DaemonPing.self, DaemonLogs.self]
     )
 }
 
@@ -620,6 +680,30 @@ struct DaemonStatus: ParsableCommand {
 
     private func format(_ value: Double) -> String {
         String(format: "%.0f", value)
+    }
+}
+
+struct DaemonLogs: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "logs", abstract: "Show recent smctld log messages (wraps `log show`).")
+
+    @Option(name: .long, help: "How far back to look, e.g. 10m, 1h, 2d.")
+    var last: String = "1h"
+
+    func run() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        process.arguments = [
+            "show",
+            "--last", last,
+            "--predicate", "subsystem == \"one.leaper.smctl\"",
+            "--style", "compact",
+            "--info"
+        ]
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw ValidationError("log show exited with status \(process.terminationStatus); check the --last value (e.g. 10m, 1h, 2d).")
+        }
     }
 }
 
@@ -717,13 +801,23 @@ private func printBatteryStatus(_ status: BatteryStatusDTO) {
     }
     print("  charging: \(status.isCharging.map { $0 ? "enabled" : "disabled" } ?? "unknown")")
     print("  plugged in: \(status.pluggedIn.map { $0 ? "yes" : "no" } ?? "unknown")")
-    print("  maintain: \(status.configuredLimit) (lower \(status.lowerBound)%, upper \(status.upperBound)%)")
+    if let minutes = status.timeToFullMinutes {
+        print("  time to full: \(hoursMinutes(minutes))")
+    } else if let minutes = status.timeToEmptyMinutes {
+        print("  time remaining: \(hoursMinutes(minutes))")
+    }
+    let forceSuffix = status.forceDischarge == true ? ", force-discharge" : ""
+    print("  maintain: \(status.configuredLimit) (lower \(status.lowerBound)%, upper \(status.upperBound)%\(forceSuffix))")
     print("  sleep policy: \(status.sleepPolicy)")
     print("  charging control: \(status.chargingControlGroup ?? "unsupported")")
     print("  adapter control: \(status.adapterControlGroup ?? "unsupported")")
     if let message = status.message {
         print("  note: \(message)")
     }
+}
+
+private func hoursMinutes(_ minutes: Int) -> String {
+    minutes < 60 ? "\(minutes)m" : "\(minutes / 60)h \(minutes % 60)m"
 }
 
 private func printFansStatus(_ status: FansStatusDTO) {
@@ -894,8 +988,8 @@ private final class DaemonClient {
         }
     }
 
-    func setChargeLimit(_ limit: String) throws {
-        let data = try SMCtlProtocolCoding.encode(SetChargeLimitRequestDTO(limit: limit))
+    func setChargeLimit(_ limit: String, forceDischarge: Bool = false) throws {
+        let data = try SMCtlProtocolCoding.encode(SetChargeLimitRequestDTO(limit: limit, forceDischarge: forceDischarge))
         let _: EmptyResponseDTO = try call { proxy, reply in
             proxy.setChargeLimit(data, withReply: reply)
         }

--- a/Tests/PolicyEngineTests/ChargeStateMachineTests.swift
+++ b/Tests/PolicyEngineTests/ChargeStateMachineTests.swift
@@ -100,11 +100,58 @@ final class ChargeStateMachineTests: XCTestCase {
         XCTAssertEqual(try ChargeLimit.parse("stop"), .disabled)
     }
 
+    func testForceDischargeCutsAdapterAboveBandAndRestoresInside() {
+        let limit = ChargeLimit(upperBound: 60, lowerDelta: 2)
+        let now = Date()
+
+        // Above the band with adapter on: cut it (plus the regular charge disable
+        // is already latched here, chargingAllowed: false).
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 80, chargingAllowed: false, adapterEnabled: true, forceDischarge: true, now: now),
+            [.setAdapterEnabled(false)]
+        )
+        // Still above: adapter already cut, nothing to do.
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 70, chargingAllowed: false, adapterEnabled: false, forceDischarge: true, now: now),
+            []
+        )
+        // Reached the upper bound: hand the adapter back.
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 60, chargingAllowed: false, adapterEnabled: false, forceDischarge: true, now: now),
+            [.setAdapterEnabled(true)]
+        )
+        // Inside the band with adapter on: steady state.
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 59, chargingAllowed: false, adapterEnabled: true, forceDischarge: true, now: now),
+            []
+        )
+    }
+
+    func testForceDischargeDoesNothingWhenAdapterStateUnknown() {
+        let limit = ChargeLimit(upperBound: 60, lowerDelta: 2)
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 80, chargingAllowed: false, adapterEnabled: nil, forceDischarge: true, now: Date()),
+            []
+        )
+    }
+
+    func testWithoutForceDischargeThePolicyNeverTouchesTheAdapter() {
+        // A manual one-shot `discharge` owns the adapter then; the maintain loop
+        // re-enabling it would break the discharge mid-flight.
+        let limit = ChargeLimit(upperBound: 60, lowerDelta: 2)
+        XCTAssertEqual(
+            evaluate(limit: limit, percent: 80, chargingAllowed: false, adapterEnabled: false, forceDischarge: false, now: Date()),
+            []
+        )
+    }
+
     private func evaluate(
         limit: ChargeLimit,
         percent: Int,
         chargingAllowed: Bool,
         pluggedIn: Bool = true,
+        adapterEnabled: Bool? = nil,
+        forceDischarge: Bool = false,
         now: Date
     ) -> [BatteryPolicyAction] {
         var machine = ChargeStateMachine(period: 10)
@@ -113,9 +160,11 @@ final class ChargeStateMachineTests: XCTestCase {
             observation: BatteryObservation(
                 chargePercent: percent,
                 isChargingAllowed: chargingAllowed,
-                isPluggedIn: pluggedIn
+                isPluggedIn: pluggedIn,
+                isAdapterEnabled: adapterEnabled
             ),
-            now: now
+            now: now,
+            forceDischarge: forceDischarge
         ).actions
     }
 }

--- a/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
+++ b/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
@@ -146,6 +146,21 @@ final class SmctlDaemonTests: XCTestCase {
         XCTAssertEqual(reloaded.config.battery.limit, "70-80")
     }
 
+    func testForceDischargeRoundtripsAndStopsWithDisabledLimit() throws {
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+        try daemon.setChargeLimit("70-80", forceDischarge: true)
+
+        let reloaded = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+        XCTAssertEqual(reloaded.config.battery.limit, "70-80")
+        XCTAssertTrue(reloaded.config.battery.force_discharge, "writeConfig must persist battery.force_discharge")
+
+        try reloaded.setChargeLimit("100", forceDischarge: true)
+
+        let stopped = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+        XCTAssertEqual(stopped.config.battery.limit, "100")
+        XCTAssertFalse(stopped.config.battery.force_discharge, "disabled charge limiting cannot keep force-discharge armed")
+    }
+
     func testAlertConfigDecodesFromToml() throws {
         try """
         [battery]

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -29,15 +29,16 @@ $ smctl sensors --watch            # 实时温度、风扇转速、封装功耗
 | 命令 | 作用 |
 |---|---|
 | `smctl sensors [--watch] [--json]` | 按传感器分组的温度、风扇转速/模式、电池、封装功耗 |
-| `smctl battery status` | 电量、充电状态、当前限充配置 |
-| `smctl battery maintain 80` / `70-80` / `stop` | 带死区的充电限制（不会在阈值附近反复充放） |
+| `smctl battery status` | 电量、充电状态、当前限充配置、剩余时间估计 |
+| `smctl battery maintain 80` / `70-80` / `stop` | 带死区的充电限制；加 `--force-discharge` 可主动放电到区间 |
+| `smctl battery charging on\|off` / `adapter on\|off` | 手动切换充电许可与适配器供电 |
 | `smctl battery charge 90` / `discharge 40` | 一次性充到目标 / 监督放电到目标 |
 | `smctl fan status` | 每个风扇的实际/目标/最小/最大转速和控制模式 |
 | `smctl fan set 2500 [--fan N]` | 手动设定目标转速 |
 | `smctl fan profile quiet\|full\|auto\|<自定义>` | 声明式风扇曲线（TOML），带滞回和变速率限制 |
 | `smctl power status [--watch] [--json]` | 热压制状态、CPU 降频幅度（限速 %）、封装功耗与输入功率 |
 | `smctl alert list\|status\|test <name>` | 温度/事件告警 → webhook、命令或日志（TOML 配置） |
-| `smctl daemon install\|uninstall\|status\|ping` | 管理特权 daemon |
+| `smctl daemon install\|uninstall\|status\|ping\|logs` | 管理特权 daemon 并查看最近日志 |
 
 策略配置在 `/etc/smctl/config.toml`——声明式、可 diff、对 dotfiles 友好。
 


### PR DESCRIPTION
## Summary

Rebuilds closed stacked PR #6 onto the current `main` after PR #4 was squash-merged.

- add `smctl battery charging on|off` and `smctl battery adapter on|off`
- add `smctl battery maintain <limit> --force-discharge`, backed by daemon-owned adapter cut/restore behavior
- reassert adapter cut during one-shot `battery discharge` so firmware resets cannot silently stall the discharge
- show IOKit time-to-empty/full estimates in `battery status`
- add `smctl daemon logs --last <range>` as a thin wrapper around the smctl unified-log predicate
- document the new CLI entries in English and Chinese README files

## Changes added while rebuilding

- persist `battery.force_discharge` in `writeConfig`, so later battery/fan writes do not drop the policy
- normalize disabled limits (`100`/`stop`) so force-discharge cannot remain armed after charge limiting is stopped
- add a daemon regression test for force-discharge config roundtrip and stop behavior

## Tests

- `swift test --disable-sandbox` — 89 tests, 0 failures
- `git diff --check`
- `git fetch origin main --quiet && git merge-tree --write-tree --merge-base $(git merge-base HEAD origin/main) HEAD origin/main`
