### PR TITLE
fix: daemon install path, TOML integer config, float write verification

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -71,6 +71,10 @@ let package = Package(
         .testTarget(
             name: "SMCtlDaemonCoreTests",
             dependencies: ["SMCtlDaemonCore"]
+        ),
+        .testTarget(
+            name: "smctlTests",
+            dependencies: ["smctl"]
         )
     ]
 )

--- a/Sources/SMCCore/SMCBackend.swift
+++ b/Sources/SMCCore/SMCBackend.swift
@@ -82,7 +82,7 @@ public extension SMCWriteBackend {
                 for verifyAttempt in 1...retryPolicy.verifyReads {
                     let readBack = try readValue(key)
                     actual = readBack.bytes
-                    if Array(actual.prefix(bytes.count)) == bytes {
+                    if smcWriteVerified(expected: bytes, actual: actual, dataType: info.dataType) {
                         return
                     }
                     if verifyAttempt < retryPolicy.verifyReads {
@@ -102,4 +102,32 @@ public extension SMCWriteBackend {
 
         throw lastError ?? SMCError.writeVerificationFailed(key: key, expected: bytes, actual: [])
     }
+}
+
+/// Whether a written value read back as the value we wrote.
+///
+/// SMC float (`flt`) writes are quantized: the firmware clears low mantissa bits,
+/// so a read-back of an interpolated fan target differs from the written bytes by
+/// a fraction of an RPM. An exact byte compare therefore reports a write failure
+/// on every policy cycle (issue #11), flooding the log and masking real failures.
+/// For `flt` keys we compare the decoded floats within a tolerance; every other
+/// type must still match exactly so a genuinely failed write is never hidden.
+func smcWriteVerified(expected: [UInt8], actual: [UInt8], dataType: UInt32) -> Bool {
+    let actualPrefix = Array(actual.prefix(expected.count))
+    if actualPrefix == expected {
+        return true
+    }
+    let types = FourCharCode.normalizedStrings(dataType)
+    guard types.contains("flt ") || types.contains("flt") else {
+        return false
+    }
+    guard
+        let written = (try? SMCDataDecoder.decode(key: "", bytes: expected, dataType: dataType))?.doubleValue,
+        let readBack = (try? SMCDataDecoder.decode(key: "", bytes: actualPrefix, dataType: dataType))?.doubleValue
+    else {
+        return false
+    }
+    // Quantization is well under 1 RPM; the relative term keeps headroom for large
+    // values without ever approaching the gap a genuinely failed write would show.
+    return abs(written - readBack) <= max(1.0, abs(written) * 0.001)
 }

--- a/Sources/SMCtlDaemonCore/Alerting.swift
+++ b/Sources/SMCtlDaemonCore/Alerting.swift
@@ -57,9 +57,9 @@ struct AlertConfig: Codable, Equatable, Sendable {
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
         on = try container.decodeIfPresent(String.self, forKey: .on) ?? ""
         sensor = try container.decodeIfPresent(String.self, forKey: .sensor)
-        above = try container.decodeIfPresent(Double.self, forKey: .above)
-        forSeconds = try container.decodeIfPresent(Double.self, forKey: .forSeconds)
-        cooldown = try container.decodeIfPresent(Double.self, forKey: .cooldown)
+        above = try container.decodeLenientDoubleIfPresent(forKey: .above)
+        forSeconds = try container.decodeLenientDoubleIfPresent(forKey: .forSeconds)
+        cooldown = try container.decodeLenientDoubleIfPresent(forKey: .cooldown)
         resolve = try container.decodeIfPresent(Bool.self, forKey: .resolve)
         action = try container.decodeIfPresent(String.self, forKey: .action)
         url = try container.decodeIfPresent(String.self, forKey: .url)

--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -92,7 +92,7 @@ struct SentryConfig: Codable, Equatable, Sendable {
         dsn = try container.decodeIfPresent(String.self, forKey: .dsn) ?? ""
         environment = try container.decodeIfPresent(String.self, forKey: .environment) ?? "production"
         debug = try container.decodeIfPresent(Bool.self, forKey: .debug) ?? false
-        let sampleRate = try container.decodeIfPresent(Double.self, forKey: .traces_sample_rate) ?? 0
+        let sampleRate = try container.decodeLenientDoubleIfPresent(forKey: .traces_sample_rate) ?? 0
         traces_sample_rate = min(max(sampleRate, 0), 1)
     }
 }
@@ -166,6 +166,22 @@ struct FanCurveConfig: Codable, Equatable, Sendable {
         self.slew_rate = slew_rate
         self.weights = weights
     }
+
+    enum CodingKeys: String, CodingKey {
+        case name, sensors, points, hysteresis, slew_rate, weights
+    }
+
+    // Custom decoding so `hysteresis`/`slew_rate` are optional (default rather than
+    // keyNotFound) and accept TOML integers — see decodeLenientDoubleIfPresent (#9).
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        sensors = try container.decodeIfPresent([String].self, forKey: .sensors) ?? []
+        points = try container.decode([[FanPointValue]].self, forKey: .points)
+        hysteresis = try container.decodeLenientDoubleIfPresent(forKey: .hysteresis) ?? 0
+        slew_rate = try container.decodeLenientDoubleIfPresent(forKey: .slew_rate)
+        weights = try container.decodeIfPresent([String: Double].self, forKey: .weights)
+    }
 }
 
 enum FanPointValue: Codable, Equatable, Sendable {
@@ -176,6 +192,13 @@ enum FanPointValue: Codable, Equatable, Sendable {
         let container = try decoder.singleValueContainer()
         if let number = try? container.decode(Double.self) {
             self = .number(number)
+            return
+        }
+        // TOML keeps integers and floats as distinct types, so `[50, "max"]` decodes
+        // the 50 as Int, not Double. Accept it as a number instead of falling through
+        // to the String branch and rejecting the whole curve.
+        if let integer = try? container.decode(Int.self) {
+            self = .number(Double(integer))
             return
         }
         let string = try container.decode(String.self).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -197,6 +220,19 @@ enum FanPointValue: Codable, Equatable, Sendable {
     }
 }
 
+/// TOML keeps integers and floats as distinct types. A hand-written `100` for a
+/// Double config field would otherwise throw a type mismatch and — via loadConfig's
+/// catch — silently reset the entire config to defaults (issue #9). Accept integers
+/// as Doubles; a genuinely wrong type still surfaces as a decoding error.
+extension KeyedDecodingContainer {
+    func decodeLenientDoubleIfPresent(forKey key: Key) throws -> Double? {
+        guard contains(key) else { return nil }
+        if let value = try? decode(Double.self, forKey: key) { return value }
+        if let integer = try? decode(Int.self, forKey: key) { return Double(integer) }
+        return try decode(Double.self, forKey: key)
+    }
+}
+
 struct SafetyConfig: Codable, Equatable, Sendable {
     var temp_ceiling: Double
     /// Advanced opt-in: allows `fan set --force` to target below the fan's reported
@@ -211,7 +247,7 @@ struct SafetyConfig: Codable, Equatable, Sendable {
     // Defensive decoding — see BatteryConfig.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        temp_ceiling = try container.decodeIfPresent(Double.self, forKey: .temp_ceiling)
+        temp_ceiling = try container.decodeLenientDoubleIfPresent(forKey: .temp_ceiling)
             ?? FanSafetyGuard.defaultCeilingCelsius
         allow_below_minimum = try container.decodeIfPresent(Bool.self, forKey: .allow_below_minimum) ?? false
     }
@@ -256,6 +292,10 @@ public final class SmctlDaemon: @unchecked Sendable {
     private static let alertHistoryLimit = 50
     private var lastEvaluation: Date?
     private var lastError: String?
+    /// Set when the on-disk config fails to parse. The daemon keeps running on
+    /// defaults, so without this the failure was invisible — `daemon status` showed
+    /// `last error: -` while silently ignoring the user's config (issue #9).
+    private var configError: String?
     private var lastWriteError: String?
     private var timer: DispatchSourceTimer?
     private var fanTimer: DispatchSourceTimer?
@@ -376,7 +416,9 @@ public final class SmctlDaemon: @unchecked Sendable {
                 periodSeconds: SmctlDaemon.period,
                 configPath: configPath,
                 lastEvaluation: lastEvaluation,
-                lastError: lastError
+                // A config parse failure is more actionable than a transient runtime
+                // error and persists until the user fixes the file, so it wins.
+                lastError: configError ?? lastError
             )
         }
     }
@@ -411,7 +453,9 @@ public final class SmctlDaemon: @unchecked Sendable {
     func reloadConfig() {
         queue.sync {
             let wasForcing = config.battery.force_discharge
-            config = Self.loadConfig(path: configPath)
+            let loaded = Self.loadConfig(path: configPath)
+            config = loaded.config
+            configError = loaded.error
             SentryReporter.startIfConfigured(config: config.sentry)
             let policy = (try? SleepPolicy.parse(config.battery.sleep_policy)) ?? .strict
             sleepMachine.setPolicy(policy)
@@ -1112,16 +1156,16 @@ public final class SmctlDaemon: @unchecked Sendable {
         return "unknown"
     }
 
-    private static func loadConfig(path: String) -> DaemonConfig {
+    private static func loadConfig(path: String) -> (config: DaemonConfig, error: String?) {
         guard FileManager.default.fileExists(atPath: path) else {
-            return DaemonConfig()
+            return (DaemonConfig(), nil)
         }
         do {
             let text = try String(contentsOfFile: path, encoding: .utf8)
-            return try TOMLDecoder().decode(DaemonConfig.self, from: text)
+            return (try TOMLDecoder().decode(DaemonConfig.self, from: text), nil)
         } catch {
             logger.error("Unable to parse \(path, privacy: .public): \(String(describing: error), privacy: .public)")
-            return DaemonConfig()
+            return (DaemonConfig(), "config at \(path) failed to parse, running on defaults: \(String(describing: error))")
         }
     }
 

--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -180,7 +180,7 @@ struct FanCurveConfig: Codable, Equatable, Sendable {
         points = try container.decode([[FanPointValue]].self, forKey: .points)
         hysteresis = try container.decodeLenientDoubleIfPresent(forKey: .hysteresis) ?? 0
         slew_rate = try container.decodeLenientDoubleIfPresent(forKey: .slew_rate)
-        weights = try container.decodeIfPresent([String: Double].self, forKey: .weights)
+        weights = try container.decodeLenientDoubleDictionaryIfPresent(forKey: .weights)
     }
 }
 
@@ -231,6 +231,29 @@ extension KeyedDecodingContainer {
         if let integer = try? decode(Int.self, forKey: key) { return Double(integer) }
         return try decode(Double.self, forKey: key)
     }
+
+    /// Same integer leniency for a `[String: Double]` field (fan curve weights):
+    /// `weights = { cpu = 2 }` decodes the values as Int and would otherwise throw,
+    /// discarding the whole config.
+    func decodeLenientDoubleDictionaryIfPresent(forKey key: Key) throws -> [String: Double]? {
+        guard contains(key) else { return nil }
+        if let value = try? decode([String: Double].self, forKey: key) { return value }
+        if let integers = try? decode([String: Int].self, forKey: key) { return integers.mapValues(Double.init) }
+        // Mixed integer/float entries: decode value-by-value (a wrong type still throws).
+        let nested = try nestedContainer(keyedBy: LenientDictKey.self, forKey: key)
+        var result: [String: Double] = [:]
+        for entry in nested.allKeys {
+            result[entry.stringValue] = try nested.decodeLenientDoubleIfPresent(forKey: entry)
+        }
+        return result
+    }
+}
+
+private struct LenientDictKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+    init?(stringValue: String) { self.stringValue = stringValue }
+    init?(intValue: Int) { self.stringValue = String(intValue); self.intValue = intValue }
 }
 
 struct SafetyConfig: Codable, Equatable, Sendable {

--- a/Sources/smctl/main.swift
+++ b/Sources/smctl/main.swift
@@ -18,6 +18,29 @@ private enum CLIFormatters {
     static let iso8601 = LockedISO8601Formatter()
 }
 
+// MARK: - Daemon install path resolution (#8)
+
+/// Real path of the running executable, independent of how it was launched. Under a
+/// PATH lookup argv[0] is just "smctl", so the old argv[0]-based resolution fell back
+/// to the working directory and `daemon install` could not find smctld (#8).
+func currentExecutablePath() -> String? {
+    var size: UInt32 = 0
+    _ = _NSGetExecutablePath(nil, &size)  // first call reports the required buffer size
+    guard size > 0 else { return nil }
+    var buffer = [CChar](repeating: 0, count: Int(size))
+    guard _NSGetExecutablePath(&buffer, &size) == 0 else { return nil }
+    return String(cString: buffer)
+}
+
+/// smctld sits next to smctl. Pure and testable. The path is deliberately left
+/// un-resolved — the stable /opt/homebrew/bin symlink, not the versioned Cellar
+/// target — so the LaunchDaemon keeps pointing at a valid binary across `brew upgrade`.
+func smctldPath(besideExecutable executablePath: String, fileExists: (String) -> Bool) -> String? {
+    let directory = URL(fileURLWithPath: executablePath).deletingLastPathComponent()
+    let candidate = directory.appendingPathComponent("smctld").standardizedFileURL.path
+    return fileExists(candidate) ? candidate : nil
+}
+
 @main
 struct SMCtl: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -727,16 +750,16 @@ struct DaemonInstall: ParsableCommand {
     static let plistPath = "/Library/LaunchDaemons/one.leaper.smctl.daemon.plist"
 
     private static func currentSmctldPath() throws -> String {
-        let rawCommand = CommandLine.arguments[0]
-        let command = rawCommand.hasPrefix("/")
-            ? URL(fileURLWithPath: rawCommand)
-            : URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(rawCommand)
-        let directory = command.deletingLastPathComponent()
-        let candidate = directory.appendingPathComponent("smctld").standardizedFileURL.path
-        if FileManager.default.isExecutableFile(atPath: candidate) {
-            return candidate
+        guard
+            let executable = currentExecutablePath(),
+            let path = smctldPath(
+                besideExecutable: executable,
+                fileExists: { FileManager.default.isExecutableFile(atPath: $0) }
+            )
+        else {
+            throw ValidationError("Could not find smctld next to the current smctl executable.")
         }
-        throw ValidationError("Could not find smctld next to the current smctl executable.")
+        return path
     }
 
     private static func plist(smctldPath: String) -> String {

--- a/Tests/SMCCoreTests/SMCWriteRetryTests.swift
+++ b/Tests/SMCCoreTests/SMCWriteRetryTests.swift
@@ -83,6 +83,80 @@ final class SMCWriteRetryTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Float write verification tolerance (issue #11)
+
+    func testFloatWriteVerificationToleratesSMCQuantization() {
+        // Real sample: wrote 3829.5 RPM, the SMC read back 3829.125 (low mantissa
+        // bits cleared). Bytes differ; the values are 0.375 RPM apart.
+        let flt = FourCharCode.unchecked("flt ")
+        let written: [UInt8] = [0x00, 0x56, 0x6f, 0x45]   // 3829.5
+        let readBack: [UInt8] = [0x00, 0x50, 0x6f, 0x45]  // 3829.125
+        XCTAssertNotEqual(written, readBack)
+        XCTAssertTrue(smcWriteVerified(expected: written, actual: readBack, dataType: flt))
+    }
+
+    func testFloatWriteVerificationStillRejectsRealMismatch() {
+        // A write that never landed (read-back still 0) must NOT be hidden by tolerance.
+        let flt = FourCharCode.unchecked("flt ")
+        let written = FanController.float32LittleEndianBytes(3000)
+        let stale = FanController.float32LittleEndianBytes(0)
+        XCTAssertFalse(smcWriteVerified(expected: written, actual: stale, dataType: flt))
+    }
+
+    func testNonFloatWriteVerificationRequiresExactBytes() {
+        // Tolerance must apply only to floats; integer/mode keys stay byte-exact.
+        let ui8 = FourCharCode.unchecked("ui8 ")
+        XCTAssertTrue(smcWriteVerified(expected: [0x02], actual: [0x02], dataType: ui8))
+        XCTAssertFalse(smcWriteVerified(expected: [0x02], actual: [0x03], dataType: ui8))
+    }
+
+    func testWriteKeyVerifiesQuantizedFloatWithoutRewriting() throws {
+        let backend = QuantizingFloatBackend(initialBytes: FanController.float32LittleEndianBytes(0))
+        try backend.writeKey(
+            "F0Tg",
+            bytes: FanController.float32LittleEndianBytes(3829.5),
+            retryPolicy: SMCWriteRetryPolicy(
+                maxAttempts: 3,
+                initialBackoffNanoseconds: 0,
+                verifyReads: 2,
+                verifyIntervalNanoseconds: 0
+            )
+        )
+        XCTAssertEqual(backend.rawWriteAttempts, 1, "a quantized read-back must verify on the first write, no rewrite")
+    }
+}
+
+/// Models SMC float quantization: the firmware stores a written float with its low
+/// mantissa bits cleared, so the read-back never byte-matches an interpolated fan
+/// target (issue #11).
+private final class QuantizingFloatBackend: SMCWriteBackend {
+    private(set) var currentBytes: [UInt8]
+    private(set) var rawWriteAttempts = 0
+
+    init(initialBytes: [UInt8]) {
+        currentBytes = initialBytes
+    }
+
+    func readKeyInfo(_ key: String) throws -> SMCKeyInfo {
+        SMCKeyInfo(dataSize: 4, dataType: FourCharCode.unchecked("flt "), dataAttributes: 0xd0)
+    }
+
+    func readValue(_ key: String) throws -> SMCReadValue {
+        SMCReadValue(key: key, info: try readKeyInfo(key), bytes: currentBytes)
+    }
+
+    func writeRawValue(_ key: String, bytes: [UInt8]) throws {
+        rawWriteAttempts += 1
+        var bits = UInt32(bytes[0]) | UInt32(bytes[1]) << 8 | UInt32(bytes[2]) << 16 | UInt32(bytes[3]) << 24
+        bits &= 0xFFFFF000  // clear the low 12 mantissa bits, as the SMC does
+        currentBytes = [
+            UInt8(bits & 0xff),
+            UInt8((bits >> 8) & 0xff),
+            UInt8((bits >> 16) & 0xff),
+            UInt8((bits >> 24) & 0xff)
+        ]
+    }
 }
 
 private final class MockWriteBackend: SMCWriteBackend {

--- a/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
+++ b/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
@@ -342,6 +342,70 @@ final class SmctlDaemonTests: XCTestCase {
         XCTAssertEqual(status.rules.first?.status, "armed")
     }
 
+    // MARK: - Config decoding tolerance (issue #9)
+
+    func testDoubleConfigFieldsAcceptTomlIntegers() throws {
+        // TOML keeps integers distinct from floats, so a natural `temp_ceiling = 95`
+        // / `points = [[105, 2000]]` used to throw a type mismatch and silently reset
+        // the ENTIRE config to defaults.
+        try """
+        [safety]
+        temp_ceiling = 95
+
+        [[fan.curves]]
+        name = "test"
+        sensors = []
+        points = [[0, "max"], [105, 2000]]
+        hysteresis = 3
+        """.write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+
+        XCTAssertFalse(
+            daemon.daemonStatus().lastError?.contains("failed to parse") ?? false,
+            "a valid integer config must not be reported as a parse error"
+        )
+        XCTAssertEqual(daemon.config.safety.temp_ceiling, 95)
+        let curve = try XCTUnwrap(daemon.config.fan.curves.first)
+        XCTAssertEqual(curve.hysteresis, 3)
+        XCTAssertEqual(curve.points, [[.number(0), .maximum], [.number(105), .number(2000)]])
+    }
+
+    func testFanCurveOmittingHysteresisDefaultsToZero() throws {
+        // `hysteresis` used to be required — omitting it threw keyNotFound and reset
+        // the whole config.
+        try """
+        [[fan.curves]]
+        name = "test"
+        sensors = []
+        points = [[0.0, "max"]]
+        """.write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+
+        XCTAssertFalse(daemon.daemonStatus().lastError?.contains("failed to parse") ?? false)
+        XCTAssertEqual(daemon.config.fan.curves.first?.hysteresis, 0)
+    }
+
+    func testMalformedConfigSurfacesInDaemonStatusAndFallsBackToDefaults() throws {
+        // Part 2: a genuine type error must be visible in `daemon status`, not
+        // silently swallowed while the daemon runs on defaults.
+        try """
+        [safety]
+        temp_ceiling = "boom"
+        """.write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+
+        let status = daemon.daemonStatus()
+        XCTAssertEqual(
+            daemon.config.safety.temp_ceiling, FanSafetyGuard.defaultCeilingCelsius,
+            "unparseable config must fall back to defaults, not crash"
+        )
+        let reported = try XCTUnwrap(status.lastError, "config parse failure must surface in status")
+        XCTAssertTrue(reported.contains("failed to parse"), "status should explain the failure: \(reported)")
+    }
+
     // MARK: - Helpers
 
     private func makeDaemon(backend: RecordingBackend, capabilities: Capabilities) -> SmctlDaemon {

--- a/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
+++ b/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
@@ -371,6 +371,38 @@ final class SmctlDaemonTests: XCTestCase {
         XCTAssertEqual(curve.points, [[.number(0), .maximum], [.number(105), .number(2000)]])
     }
 
+    func testFanCurveWeightsAcceptIntegerValues() throws {
+        // Integer weights are the natural way to write them and must not throw and
+        // discard the whole config (gap caught in preflight review).
+        try """
+        [[fan.curves]]
+        name = "test"
+        sensors = ["Tp01", "Tg05"]
+        points = [[0.0, "max"]]
+        weights = { Tp01 = 2, Tg05 = 1 }
+        """.write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+
+        XCTAssertFalse(daemon.daemonStatus().lastError?.contains("failed to parse") ?? false)
+        XCTAssertEqual(daemon.config.fan.curves.first?.weights, ["Tp01": 2, "Tg05": 1])
+    }
+
+    func testFanCurveWeightsAcceptMixedIntegerAndFloat() throws {
+        try """
+        [[fan.curves]]
+        name = "test"
+        sensors = ["Tp01", "Tg05"]
+        points = [[0.0, "max"]]
+        weights = { Tp01 = 2, Tg05 = 1.5 }
+        """.write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        let daemon = makeDaemon(backend: RecordingBackend(), capabilities: .oneFan)
+
+        XCTAssertFalse(daemon.daemonStatus().lastError?.contains("failed to parse") ?? false)
+        XCTAssertEqual(daemon.config.fan.curves.first?.weights, ["Tp01": 2, "Tg05": 1.5])
+    }
+
     func testFanCurveOmittingHysteresisDefaultsToZero() throws {
         // `hysteresis` used to be required — omitting it threw keyNotFound and reset
         // the whole config.

--- a/Tests/smctlTests/DaemonInstallPathTests.swift
+++ b/Tests/smctlTests/DaemonInstallPathTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import smctl
+
+final class DaemonInstallPathTests: XCTestCase {
+    func testResolvesSmctldNextToExecutable() {
+        let path = smctldPath(
+            besideExecutable: "/opt/homebrew/bin/smctl",
+            fileExists: { $0 == "/opt/homebrew/bin/smctld" }
+        )
+        XCTAssertEqual(path, "/opt/homebrew/bin/smctld")
+    }
+
+    func testKeepsSymlinkDirectorySoItSurvivesBrewUpgrade() {
+        // Must NOT resolve /opt/homebrew/bin's symlink to the versioned Cellar path;
+        // the LaunchDaemon points at the stable symlink directory (#8).
+        let path = smctldPath(
+            besideExecutable: "/opt/homebrew/bin/smctl",
+            fileExists: { _ in true }
+        )
+        XCTAssertEqual(path, "/opt/homebrew/bin/smctld")
+    }
+
+    func testReturnsNilWhenSiblingMissing() {
+        XCTAssertNil(
+            smctldPath(besideExecutable: "/usr/local/bin/smctl", fileExists: { _ in false })
+        )
+    }
+
+    func testNormalizesRelativeComponents() {
+        let path = smctldPath(
+            besideExecutable: "/opt/homebrew/bin/./smctl",
+            fileExists: { $0 == "/opt/homebrew/bin/smctld" }
+        )
+        XCTAssertEqual(path, "/opt/homebrew/bin/smctld")
+    }
+}


### PR DESCRIPTION
Fixes four open issues found on real machines, each with a root-cause fix and tests. No source for the fixes was changed beyond what's described; full suite is green (107 tests).

## #9 — TOML integers rejected, config silently reset
TOML keeps integers and floats as distinct types, so a hand-written `temp_ceiling = 100`, `points = [[50, 2000]]`, or `hysteresis = 0` failed to decode into Double fields and — via `loadConfig`'s catch — silently reset the **entire** config to defaults while `daemon status` showed `last error: -`.
- Lenient Double decoder shared across config types (integer accepted as Double; a genuinely wrong type still surfaces as a decode error).
- `FanPointValue` accepts integer points; `FanCurveConfig` gets a custom decoder so `hysteresis`/`slew_rate` are optional + integer-tolerant.
- Applied to `safety.temp_ceiling`, `sentry.traces_sample_rate`, alert `above`/`for`/`cooldown`.
- Config parse failures now recorded and shown in `daemon status` instead of swallowed.

## #11 — F0Tg write-verification false positive
The SMC quantizes float writes (low mantissa bits cleared), so a read-back of an interpolated fan target never byte-matches. Exact-byte verification logged a failure **every** policy cycle, flooding the log and masking real failures.
- Compare decoded floats within tolerance (< 1 RPM absolute, 0.1% relative) for `flt` keys; all other types stay byte-exact so a genuine failed write is never hidden.

## #8 / #12 — `daemon install` can't find smctld
Resolution used `CommandLine.arguments[0]`; under a PATH lookup that's just `smctl`, so it looked in the working directory and failed unless invoked by absolute path.
- Resolve the running executable with `_NSGetExecutablePath`. The sibling path is left un-resolved (the stable `/opt/homebrew/bin` symlink, not the versioned Cellar target) so the LaunchDaemon survives `brew upgrade`.
- Pure, tested derivation; adds a `smctlTests` target.

Closes #8, #9, #11, #12.