### PR TITLE
feat: display module — brightness and power control over DDC/CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .swiftpm/
 DerivedData/
 dist/
+.claude/worktrees/

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,14 @@ let package = Package(
         .target(name: "PolicyEngine"),
         .target(name: "SMCtlProtocol"),
         .target(
+            name: "DisplayDDC",
+            linkerSettings: [
+                .linkedFramework("IOKit"),
+                .linkedFramework("CoreGraphics"),
+                .linkedFramework("CoreDisplay")
+            ]
+        ),
+        .target(
             name: "SMCtlDaemonCore",
             dependencies: [
                 "SMCCore",
@@ -53,6 +61,7 @@ let package = Package(
             dependencies: [
                 "SMCCore",
                 "SMCtlProtocol",
+                "DisplayDDC",
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]
         ),
@@ -74,7 +83,7 @@ let package = Package(
         ),
         .testTarget(
             name: "smctlTests",
-            dependencies: ["smctl"]
+            dependencies: ["smctl", "DisplayDDC"]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ smctl sensors --watch            # live temperatures, fan RPM, package power
 | `smctl fan set 2500 [--fan N]` | Manual fan target |
 | `smctl fan profile quiet\|full\|auto\|<custom>` | Declarative fan curves (TOML), hysteresis + slew-rate limited |
 | `smctl power status [--watch] [--json]` | Thermal pressure, CPU throttling (% speed limit), system/package + input power |
+| `smctl display list` / `brightness [0-100]` / `power on\|off` | External display brightness and power over DDC/CI; the display stays in the macOS layout while off |
 | `smctl alert list\|status\|test <name>` | Temperature/event alerts → webhook, command, or log (configured in TOML) |
 | `smctl daemon install\|uninstall\|status\|ping\|logs` | Manage the privileged helper and inspect recent daemon logs |
 

--- a/Sources/DisplayDDC/i2c.c
+++ b/Sources/DisplayDDC/i2c.c
@@ -1,0 +1,83 @@
+// Vendored and adapted from m1ddc sources/i2c.m
+// (https://github.com/waydabber/m1ddc), Copyright (c) 2021 waydabber, MIT.
+#include "DisplayDDC.h"
+
+#include <string.h>
+#include <unistd.h>
+
+#define DDC_DEFAULT_INPUT_ADDRESS 0x51
+#define DDC_ALTERNATE_INPUT_ADDRESS 0x50
+#define DDC_VCP_INPUT_ALT 0xF4
+#define DDC_WAIT 10000  // usec; some displays need up to 50000
+#define DDC_ITERATIONS 2
+
+static int getBytesUsed(const UInt8 *data) {
+    int bytes = 0;
+    for (int i = 0; i < DDC_BUFFER_SIZE; ++i) {
+        if (data[i] != 0) {
+            bytes = i + 1;
+        }
+    }
+    return bytes;
+}
+
+DDCPacket ddcCreatePacket(UInt8 attrCode) {
+    DDCPacket packet = {};
+    packet.data[2] = attrCode;
+    packet.inputAddr = attrCode == DDC_VCP_INPUT_ALT ? DDC_ALTERNATE_INPUT_ADDRESS : DDC_DEFAULT_INPUT_ADDRESS;
+    return packet;
+}
+
+void ddcPrepareRead(UInt8 *data) {
+    data[0] = 0x82;
+    data[1] = 0x01;
+    data[3] = 0x6e ^ data[0] ^ data[1] ^ data[2] ^ data[3];
+}
+
+void ddcPrepareWrite(DDCPacket *packet, UInt16 newValue) {
+    UInt8 *data = packet->data;
+    data[0] = 0x84;
+    data[1] = 0x03;
+    data[3] = newValue >> 8;
+    data[4] = newValue & 255;
+    data[5] = 0x6E ^ packet->inputAddr ^ data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4];
+}
+
+static IOReturn performDDCWrite(IOAVServiceRef avService, DDCPacket *packet) {
+    IOReturn ret = kIOReturnSuccess;
+    for (int i = 0; i < DDC_ITERATIONS; ++i) {
+        usleep(DDC_WAIT);
+        if ((ret = IOAVServiceWriteI2C(avService, 0x37, packet->inputAddr, packet->data, getBytesUsed(packet->data)))) {
+            return ret;
+        }
+    }
+    return ret;
+}
+
+IOReturn ddcRead(IOAVServiceRef avService, UInt8 attrCode, DDCValue *outValue) {
+    DDCPacket packet = ddcCreatePacket(attrCode);
+    ddcPrepareRead(packet.data);
+
+    IOReturn err = performDDCWrite(avService, &packet);
+    if (err) {
+        return err;
+    }
+
+    UInt8 reply[DDC_BUFFER_SIZE] = {0};
+    usleep(DDC_WAIT);
+    err = IOAVServiceReadI2C(avService, 0x37, packet.inputAddr, reply, 12);
+    if (err) {
+        return err;
+    }
+
+    // DDC/CI "Get VCP Feature Reply": max in bytes [6..7], current in [8..9], big-endian.
+    outValue->maxValue = (reply[6] << 8) | reply[7];
+    outValue->curValue = (reply[8] << 8) | reply[9];
+    return kIOReturnSuccess;
+}
+
+IOReturn ddcWrite(IOAVServiceRef avService, UInt8 attrCode, UInt16 value) {
+    DDCPacket packet = ddcCreatePacket(attrCode);
+    ddcPrepareWrite(&packet, value);
+    return performDDCWrite(avService, &packet);
+}

--- a/Sources/DisplayDDC/include/DisplayDDC.h
+++ b/Sources/DisplayDDC/include/DisplayDDC.h
@@ -1,0 +1,68 @@
+// DDC/CI control for external displays on Apple Silicon, via the private
+// IOAVService I2C interface (chip 0x37, data offset 0x51).
+//
+// Vendored and adapted from m1ddc (https://github.com/waydabber/m1ddc),
+// Copyright (c) 2021 waydabber, MIT License. Converted from Objective-C to
+// plain C / CoreFoundation so SwiftPM can build it without ARC bridging.
+#ifndef DISPLAY_DDC_H
+#define DISPLAY_DDC_H
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <IOKit/IOKitLib.h>
+
+#define DDC_MAX_DISPLAYS 8
+#define DDC_BUFFER_SIZE 256
+
+// VCP feature codes (MCCS)
+#define DDC_VCP_LUMINANCE 0x10
+#define DDC_VCP_POWER_MODE 0xD6  // 1 = on, 4 = soft off
+
+// IOAVServiceRef is a private CoreDisplay class.
+typedef CFTypeRef IOAVServiceRef;
+
+typedef struct {
+    CGDirectDisplayID id;
+    CFStringRef ioLocation;   // retained; NULL only for skipped slots
+    CFStringRef uuid;         // retained
+    CFStringRef productName;  // retained, may be NULL
+    UInt32 serial;
+    UInt32 model;
+    UInt32 vendor;
+} DDCDisplayInfo;
+
+typedef struct {
+    UInt8 data[DDC_BUFFER_SIZE];
+    UInt8 inputAddr;
+} DDCPacket;
+
+typedef struct {
+    int curValue;
+    int maxValue;
+} DDCValue;
+
+// Packet construction (pure functions, unit-testable without hardware)
+DDCPacket ddcCreatePacket(UInt8 attrCode);
+void ddcPrepareRead(UInt8 *data);
+void ddcPrepareWrite(DDCPacket *packet, UInt16 newValue);
+
+// Fills `infos` with online displays that expose an IORegistry location
+// (i.e. physically connected panels; virtual displays are skipped).
+// Returns the number of entries written. CFString fields are retained.
+int ddcCopyOnlineDisplayInfos(DDCDisplayInfo *infos, int maxCount);
+
+// Returns a retained IOAVService for the display's external DCP port,
+// or NULL if the display has no DDC-capable connection.
+IOAVServiceRef ddcCopyDisplayAVService(const DDCDisplayInfo *info);
+
+// VCP feature read/write. Return kIOReturnSuccess on success.
+IOReturn ddcRead(IOAVServiceRef avService, UInt8 attrCode, DDCValue *outValue);
+IOReturn ddcWrite(IOAVServiceRef avService, UInt8 attrCode, UInt16 value);
+
+// Private symbols from CoreDisplay.framework
+extern IOAVServiceRef IOAVServiceCreateWithService(CFAllocatorRef allocator, io_service_t service);
+extern IOReturn IOAVServiceReadI2C(IOAVServiceRef service, uint32_t chipAddress, uint32_t offset, void *outputBuffer, uint32_t outputBufferSize);
+extern IOReturn IOAVServiceWriteI2C(IOAVServiceRef service, uint32_t chipAddress, uint32_t dataAddress, void *inputBuffer, uint32_t inputBufferSize);
+extern CFDictionaryRef CoreDisplay_DisplayCreateInfoDictionary(CGDirectDisplayID display);
+
+#endif

--- a/Sources/DisplayDDC/ioregistry.c
+++ b/Sources/DisplayDDC/ioregistry.c
@@ -1,0 +1,121 @@
+// Vendored and adapted from m1ddc sources/ioregistry.m
+// (https://github.com/waydabber/m1ddc), Copyright (c) 2021 waydabber, MIT.
+#include "DisplayDDC.h"
+
+#include <string.h>
+
+static CFTypeRef copySearchedProperty(io_service_t service, CFStringRef key) {
+    return IORegistryEntrySearchCFProperty(service, kIOServicePlane, key, kCFAllocatorDefault, kIORegistryIterateRecursively);
+}
+
+int ddcCopyOnlineDisplayInfos(DDCDisplayInfo *infos, int maxCount) {
+    CGDisplayCount screenCount = 0;
+    CGDirectDisplayID screenList[DDC_MAX_DISPLAYS];
+    CGGetOnlineDisplayList(DDC_MAX_DISPLAYS, screenList, &screenCount);
+
+    int valid = 0;
+    for (int i = 0; i < (int)screenCount && valid < maxCount; i++) {
+        DDCDisplayInfo *display = &infos[valid];
+        memset(display, 0, sizeof(*display));
+        display->id = screenList[i];
+
+        // Private API shortcut to the system UUID and IORegistry location.
+        CFDictionaryRef infoDict = CoreDisplay_DisplayCreateInfoDictionary(display->id);
+        if (infoDict == NULL) {
+            continue;
+        }
+
+        CFStringRef uuid = CFDictionaryGetValue(infoDict, CFSTR("kCGDisplayUUID"));
+        CFStringRef ioLocation = CFDictionaryGetValue(infoDict, CFSTR("IODisplayLocation"));
+        // Virtual displays (Sidecar/AirPlay) lack these properties.
+        if (uuid == NULL || ioLocation == NULL) {
+            CFRelease(infoDict);
+            continue;
+        }
+
+        display->serial = CGDisplaySerialNumber(display->id);
+        display->model = CGDisplayModelNumber(display->id);
+        display->vendor = CGDisplayVendorNumber(display->id);
+        display->uuid = CFRetain(uuid);
+        display->ioLocation = CFRetain(ioLocation);
+
+        io_registry_entry_t adapter = IORegistryEntryCopyFromPath(kIOMainPortDefault, ioLocation);
+        if (adapter != MACH_PORT_NULL) {
+            CFTypeRef attrs = copySearchedProperty(adapter, CFSTR("DisplayAttributes"));
+            if (attrs != NULL && CFGetTypeID(attrs) == CFDictionaryGetTypeID()) {
+                CFTypeRef product = CFDictionaryGetValue((CFDictionaryRef)attrs, CFSTR("ProductAttributes"));
+                if (product != NULL && CFGetTypeID(product) == CFDictionaryGetTypeID()) {
+                    CFTypeRef name = CFDictionaryGetValue((CFDictionaryRef)product, CFSTR("ProductName"));
+                    if (name != NULL && CFGetTypeID(name) == CFStringGetTypeID()) {
+                        display->productName = CFRetain(name);
+                    }
+                }
+            }
+            if (attrs != NULL) {
+                CFRelease(attrs);
+            }
+            IOObjectRelease(adapter);
+        }
+
+        CFRelease(infoDict);
+        valid++;
+    }
+    return valid;
+}
+
+IOAVServiceRef ddcCopyDisplayAVService(const DDCDisplayInfo *info) {
+    if (info->ioLocation == NULL) {
+        return NULL;
+    }
+
+    char targetPath[1024];
+    if (!CFStringGetCString(info->ioLocation, targetPath, sizeof(targetPath), kCFStringEncodingASCII)) {
+        return NULL;
+    }
+
+    io_registry_entry_t root = IORegistryGetRootEntry(kIOMainPortDefault);
+    io_iterator_t iter;
+    if (IORegistryEntryCreateIterator(root, kIOServicePlane, kIORegistryIterateRecursively, &iter) != KERN_SUCCESS) {
+        return NULL;
+    }
+
+    IOAVServiceRef avService = NULL;
+    io_service_t service;
+    // Find the display's adapter entry, then the first *external* DCPAVServiceProxy below it.
+    while (avService == NULL && (service = IOIteratorNext(iter)) != MACH_PORT_NULL) {
+        io_string_t servicePath;
+        IORegistryEntryGetPath(service, kIOServicePlane, servicePath);
+        if (strcmp(servicePath, targetPath) != 0) {
+            IOObjectRelease(service);
+            continue;
+        }
+        IOObjectRelease(service);
+
+        while ((service = IOIteratorNext(iter)) != MACH_PORT_NULL) {
+            io_name_t name;
+            IORegistryEntryGetName(service, name);
+            if (strcmp(name, "DCPAVServiceProxy") == 0) {
+                IOAVServiceRef candidate = IOAVServiceCreateWithService(kCFAllocatorDefault, service);
+                CFTypeRef location = copySearchedProperty(service, CFSTR("Location"));
+                bool external = location != NULL
+                    && CFGetTypeID(location) == CFStringGetTypeID()
+                    && CFStringCompare((CFStringRef)location, CFSTR("External"), 0) == kCFCompareEqualTo;
+                if (location != NULL) {
+                    CFRelease(location);
+                }
+                if (candidate != NULL && external) {
+                    avService = candidate;
+                    IOObjectRelease(service);
+                    break;
+                }
+                if (candidate != NULL) {
+                    CFRelease(candidate);
+                }
+            }
+            IOObjectRelease(service);
+        }
+        break;
+    }
+    IOObjectRelease(iter);
+    return avService;
+}

--- a/Sources/smctl/Display.swift
+++ b/Sources/smctl/Display.swift
@@ -1,0 +1,218 @@
+import ArgumentParser
+import DisplayDDC
+import Foundation
+
+// MARK: - DDC display access
+
+/// External display reachable over DDC/CI. `raw` keeps the retained CFString
+/// fields from the C layer alive; smctl is a one-shot process, so they are
+/// never released.
+struct ExternalDisplay {
+    let index: Int
+    let name: String
+    let uuid: String
+    let raw: DDCDisplayInfo
+}
+
+enum DisplayControl {
+    static func onlineDisplays() -> [ExternalDisplay] {
+        var infos = [DDCDisplayInfo](repeating: DDCDisplayInfo(), count: Int(DDC_MAX_DISPLAYS))
+        let count = Int(ddcCopyOnlineDisplayInfos(&infos, DDC_MAX_DISPLAYS))
+        return (0..<count).map { i in
+            ExternalDisplay(
+                index: i + 1,
+                name: infos[i].productName.map { $0.takeUnretainedValue() as String } ?? "Unknown Display",
+                uuid: infos[i].uuid.map { $0.takeUnretainedValue() as String } ?? "",
+                raw: infos[i]
+            )
+        }
+    }
+
+    static func resolve(_ selector: String?, in displays: [ExternalDisplay]) throws -> ExternalDisplay {
+        guard !displays.isEmpty else {
+            throw ValidationError("No external display found.")
+        }
+        guard let selector else {
+            if displays.count == 1 { return displays[0] }
+            let list = displays.map { "  [\($0.index)] \($0.name) (\($0.uuid))" }.joined(separator: "\n")
+            throw ValidationError("Multiple displays connected; pick one with --display <index|uuid>:\n\(list)")
+        }
+        if let index = Int(selector) {
+            guard let match = displays.first(where: { $0.index == index }) else {
+                throw ValidationError("No display with index \(index). See 'smctl display list'.")
+            }
+            return match
+        }
+        guard let match = displays.first(where: { $0.uuid.caseInsensitiveCompare(selector) == .orderedSame }) else {
+            throw ValidationError("No display with UUID \(selector). See 'smctl display list'.")
+        }
+        return match
+    }
+
+    static func avService(for display: ExternalDisplay) throws -> IOAVService {
+        var raw = display.raw
+        guard let service = ddcCopyDisplayAVService(&raw) else {
+            throw ValidationError("Display \(display.index) (\(display.name)) has no DDC-capable connection.")
+        }
+        return service.takeRetainedValue()
+    }
+
+    static func read(_ service: IOAVService, _ code: UInt8) throws -> DDCValue {
+        var value = DDCValue()
+        let err = ddcRead(service, code, &value)
+        guard err == kIOReturnSuccess else {
+            throw ValidationError("DDC read failed: \(String(cString: mach_error_string(err)))")
+        }
+        return value
+    }
+
+    static func write(_ service: IOAVService, _ code: UInt8, _ value: UInt16) throws {
+        let err = ddcWrite(service, code, value)
+        guard err == kIOReturnSuccess else {
+            throw ValidationError("DDC write failed: \(String(cString: mach_error_string(err)))")
+        }
+    }
+}
+
+// MARK: - Commands
+
+struct Display: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "display",
+        abstract: "Control external displays over DDC/CI.",
+        subcommands: [DisplayList.self, DisplayBrightness.self, DisplayPower.self]
+    )
+}
+
+struct DisplayList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List external displays."
+    )
+
+    @Flag(name: .long, help: "Print machine-readable JSON.")
+    var json = false
+
+    private struct Entry: Codable {
+        let index: Int
+        let name: String
+        let uuid: String
+        let vendor: UInt32
+        let model: UInt32
+        let serial: UInt32
+    }
+
+    func run() throws {
+        let displays = DisplayControl.onlineDisplays()
+        if json {
+            let entries = displays.map {
+                Entry(index: $0.index, name: $0.name, uuid: $0.uuid,
+                      vendor: $0.raw.vendor, model: $0.raw.model, serial: $0.raw.serial)
+            }
+            print(try CLIJSON.encodeString(entries))
+            return
+        }
+        if displays.isEmpty {
+            print("No external display found.")
+            return
+        }
+        for display in displays {
+            print("[\(display.index)] \(display.name) (\(display.uuid))")
+        }
+    }
+}
+
+struct DisplayBrightness: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "brightness",
+        abstract: "Get or set display brightness (DDC luminance)."
+    )
+
+    @Argument(help: "New brightness (0-100). Omit to read the current value.")
+    var value: Int?
+
+    @Option(name: .customLong("display"), help: "Display index or UUID (see 'smctl display list').")
+    var display: String?
+
+    @Flag(name: .long, help: "Print machine-readable JSON.")
+    var json = false
+
+    private struct Reading: Codable {
+        let display: String
+        let uuid: String
+        let brightness: Int
+        let max: Int
+    }
+
+    func run() throws {
+        let target = try DisplayControl.resolve(display, in: DisplayControl.onlineDisplays())
+        let service = try DisplayControl.avService(for: target)
+
+        if let value {
+            guard (0...100).contains(value) else {
+                throw ValidationError("Brightness must be between 0 and 100.")
+            }
+            try DisplayControl.write(service, UInt8(DDC_VCP_LUMINANCE), UInt16(value))
+            let after = try DisplayControl.read(service, UInt8(DDC_VCP_LUMINANCE))
+            if after.curValue != value {
+                FileHandle.standardError.write(Data("warning: display reports \(after.curValue) after writing \(value)\n".utf8))
+            }
+        }
+
+        let reading = try DisplayControl.read(service, UInt8(DDC_VCP_LUMINANCE))
+        if json {
+            print(try CLIJSON.encodeString(Reading(
+                display: target.name, uuid: target.uuid,
+                brightness: Int(reading.curValue), max: Int(reading.maxValue))))
+        } else {
+            print(reading.curValue)
+        }
+    }
+}
+
+struct DisplayPower: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "power",
+        abstract: "Get or set display power over DDC (the display stays in the macOS layout while off)."
+    )
+
+    enum State: String, ExpressibleByArgument, CaseIterable {
+        case on
+        case off
+
+        var vcpValue: UInt16 { self == .on ? 1 : 4 }
+    }
+
+    @Argument(help: "'on' or 'off'. Omit to read the current state.")
+    var state: State?
+
+    @Option(name: .customLong("display"), help: "Display index or UUID (see 'smctl display list').")
+    var display: String?
+
+    func run() throws {
+        let target = try DisplayControl.resolve(display, in: DisplayControl.onlineDisplays())
+        let service = try DisplayControl.avService(for: target)
+
+        guard let state else {
+            let reading = try DisplayControl.read(service, UInt8(DDC_VCP_POWER_MODE))
+            print(reading.curValue == 1 ? "on" : "off")
+            return
+        }
+
+        try DisplayControl.write(service, UInt8(DDC_VCP_POWER_MODE), state.vcpValue)
+
+        // Panels take a few seconds to change power state; poll before judging.
+        for _ in 0..<5 {
+            sleep(1)
+            if let reading = try? DisplayControl.read(service, UInt8(DDC_VCP_POWER_MODE)),
+               reading.curValue == Int(state.vcpValue) {
+                print("\(target.name): \(state.rawValue)")
+                if state == .off {
+                    print("Wake it with: smctl display power on --display \(target.index)")
+                }
+                return
+            }
+        }
+        FileHandle.standardError.write(Data("warning: could not confirm power state over DDC; check the display\n".utf8))
+    }
+}

--- a/Sources/smctl/SMCtl.swift
+++ b/Sources/smctl/SMCtl.swift
@@ -47,7 +47,7 @@ struct SMCtl: ParsableCommand {
         commandName: "smctl",
         abstract: "Mac hardware control utility.",
         version: SMCtlProtocolInfo.version,
-        subcommands: [Sensors.self, Fan.self, Battery.self, Power.self, Alert.self, Daemon.self, Debug.self]
+        subcommands: [Sensors.self, Fan.self, Battery.self, Power.self, Display.self, Alert.self, Daemon.self, Debug.self]
     )
 }
 
@@ -1143,7 +1143,7 @@ private final class XPCResultBox: @unchecked Sendable {
     var error: String?
 }
 
-private enum CLIJSON {
+enum CLIJSON {
     static func encodeString<T: Encodable>(_ value: T) throws -> String {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Tests/smctlTests/DisplayDDCPacketTests.swift
+++ b/Tests/smctlTests/DisplayDDCPacketTests.swift
@@ -1,0 +1,31 @@
+import DisplayDDC
+import XCTest
+
+/// DDC/CI packet construction per the MCCS spec: checksum is XOR of the
+/// destination address (0x6E), the data offset, and all payload bytes.
+final class DisplayDDCPacketTests: XCTestCase {
+    func testWritePacketForLuminance40() {
+        var packet = ddcCreatePacket(UInt8(DDC_VCP_LUMINANCE))
+        XCTAssertEqual(packet.inputAddr, 0x51)
+        ddcPrepareWrite(&packet, 40)
+        withUnsafeBytes(of: packet.data) { data in
+            XCTAssertEqual(data[0], 0x84)
+            XCTAssertEqual(data[1], 0x03)
+            XCTAssertEqual(data[2], 0x10)
+            XCTAssertEqual(data[3], 0x00)
+            XCTAssertEqual(data[4], 40)
+            XCTAssertEqual(data[5], 0x6E ^ 0x51 ^ 0x84 ^ 0x03 ^ 0x10 ^ 0x00 ^ 40)
+        }
+    }
+
+    func testReadPacketForPowerMode() {
+        var packet = ddcCreatePacket(UInt8(DDC_VCP_POWER_MODE))
+        ddcPrepareRead(&packet.data.0)
+        withUnsafeBytes(of: packet.data) { data in
+            XCTAssertEqual(data[0], 0x82)
+            XCTAssertEqual(data[1], 0x01)
+            XCTAssertEqual(data[2], 0xD6)
+            XCTAssertEqual(data[3], 0x6E ^ 0x82 ^ 0x01 ^ 0xD6)
+        }
+    }
+}

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -37,6 +37,7 @@ $ smctl sensors --watch            # 实时温度、风扇转速、封装功耗
 | `smctl fan set 2500 [--fan N]` | 手动设定目标转速 |
 | `smctl fan profile quiet\|full\|auto\|<自定义>` | 声明式风扇曲线（TOML），带滞回和变速率限制 |
 | `smctl power status [--watch] [--json]` | 热压制状态、CPU 降频幅度（限速 %）、封装功耗与输入功率 |
+| `smctl display list` / `brightness [0-100]` / `power on\|off` | 外接显示器亮度与电源（DDC/CI）；关闭后显示器仍留在 macOS 布局中，窗口不会被重排 |
 | `smctl alert list\|status\|test <name>` | 温度/事件告警 → webhook、命令或日志（TOML 配置） |
 | `smctl daemon install\|uninstall\|status\|ping\|logs` | 管理特权 daemon 并查看最近日志 |
 


### PR DESCRIPTION
## Summary
- New `smctl display` command group for external displays on Apple Silicon: `list [--json]`, `brightness [0-100] [--display <index|uuid>] [--json]`, `power on|off [--display …]`
- New `DisplayDDC` C target: DDC/CI over the private IOAVService I2C interface, vendored from [m1ddc](https://github.com/waydabber/m1ddc) (MIT) and converted from Objective-C to plain C/CoreFoundation
- `power off` = VCP 0xD6 soft-off: panel drops signal but stays in the macOS layout (no window rearrangement) and wakes back over DDC
- `main.swift` → `SMCtl.swift` rename (Swift forbids `@main` alongside a `main.swift` in a multi-file target)

## Why not a true layout disconnect
`CGSConfigureDisplayEnabled` (displayplacer route) was tested on this machine and is a one-way door: the disabled display disappears from every layer (CG, IOKit, BetterDisplay), survives replug and full sleep, and only comes back after deleting the WindowServer display plists and rebooting. Documented in project memory; deliberately not shipped.

## Test plan
- [x] 112 unit tests pass (2 new: DDC packet checksums, no hardware needed)
- [x] Hardware-verified on M4 mini with Redmi 27 NU + AOC 27G2G4 (both 4K): list/JSON, brightness get/set/restore + write-verify, power off→on cycle, multi-display selector errors