### PR TITLE
fix(battery): fall back to adapter control when charge keys are blocked (macOS 27)

### DIFF
--- a/Sources/SMCtlDaemonCore/Daemon.swift
+++ b/Sources/SMCtlDaemonCore/Daemon.swift
@@ -678,8 +678,11 @@ public final class SmctlDaemon: @unchecked Sendable {
     }
 
     private func readChargingEnabledLocked() -> Bool? {
+        // Mirror the adapter-fallback in applyChargingLocked: when the charge
+        // keys are unavailable, adapter power is what gates charging, so it is
+        // also what reports the charging state.
         guard let group = capabilities.chargingControl, let value = try? backend?.readValue(group.statusKey) else {
-            return nil
+            return capabilities.adapterControl != nil ? readAdapterEnabledLocked() : nil
         }
         return value.bytes.allSatisfy { $0 == 0 }
     }
@@ -722,8 +725,18 @@ public final class SmctlDaemon: @unchecked Sendable {
         guard let backend else {
             throw DaemonError.unsupported("AppleSMC is not available.")
         }
+        // macOS 27 / Apple Silicon: the charge-inhibit keys (CHLS, CH0J) are
+        // refused by the AppleSMC kernel driver with kIOReturnNotPrivileged for
+        // every userspace caller, root included. Adapter power control (CHIE) is
+        // still writable and produces the same observable result — cutting the
+        // adapter stops the charge and lets the pack sail down. Fall back to it
+        // so charge limiting keeps working where it otherwise could not.
         guard let group = capabilities.chargingControl else {
-            throw DaemonError.unsupported("Charging control keys are not available on this Mac/system.")
+            guard capabilities.adapterControl != nil else {
+                throw DaemonError.unsupported("Charging control keys are not available on this Mac/system.")
+            }
+            try applyAdapterLocked(enabled)
+            return
         }
         for write in enabled ? group.enableWrites : group.disableWrites {
             try writeSMCKeyLocked(write.key, bytes: write.bytes, backend: backend)
@@ -1111,6 +1124,8 @@ public final class SmctlDaemon: @unchecked Sendable {
             statusMessage = message
         } else if observation == nil {
             statusMessage = "No readable battery was found. Battery commands are read-only or unsupported on this Mac."
+        } else if capabilities.chargingControl == nil, capabilities.adapterControl != nil {
+            statusMessage = "Charging control keys are unavailable; using adapter power control instead (the Mac runs on battery while the limit holds)."
         } else if capabilities.chargingControl == nil {
             statusMessage = "Charging control keys are unavailable; policy writes are unsupported on this Mac/system."
         } else {

--- a/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
+++ b/Tests/SMCtlDaemonCoreTests/SmctlDaemonTests.swift
@@ -93,6 +93,52 @@ final class SmctlDaemonTests: XCTestCase {
         )
     }
 
+    func testChargeLimitFallsBackToAdapterWhenChargingKeysUnavailable() throws {
+        let backend = RecordingBackend()
+        backend.values["BUIC"] = [85]          // charge percent (ui8)
+        backend.values["CHIE"] = [0]           // adapter enabled
+        backend.values["AC-W"] = [1]           // plugged in
+        let daemon = makeDaemon(backend: backend, capabilities: .oneFanAdapterOnly)
+
+        try daemon.setChargeLimit("70-80")     // 85% > upper bound 80
+
+        XCTAssertTrue(
+            backend.writes.contains { $0.key == "CHIE" && $0.bytes == [0x08] },
+            "adapter power must be cut when the charge keys are unavailable; writes: \(backend.writes)"
+        )
+    }
+
+    func testChargeLimitRestoresAdapterBelowLowerBound() throws {
+        let backend = RecordingBackend()
+        backend.values["BUIC"] = [50]          // below the 60 lower bound
+        backend.values["CHIE"] = [0x08]        // adapter currently cut
+        backend.values["AC-W"] = [1]
+        let daemon = makeDaemon(backend: backend, capabilities: .oneFanAdapterOnly)
+
+        try daemon.setChargeLimit("60-70")
+
+        XCTAssertTrue(
+            backend.writes.contains { $0.key == "CHIE" && $0.bytes == [0x00] },
+            "adapter power must be restored below the lower bound; writes: \(backend.writes)"
+        )
+    }
+
+    func testChargeLimitStillUnsupportedWithNoControlKeysAtAll() throws {
+        let backend = RecordingBackend()
+        backend.values["BUIC"] = [85]
+        backend.values["AC-W"] = [1]
+        var capabilities = Capabilities.oneFanAdapterOnly
+        capabilities.adapterControl = nil       // neither mechanism available
+        let daemon = makeDaemon(backend: backend, capabilities: capabilities)
+
+        try daemon.setChargeLimit("70-80")
+
+        XCTAssertTrue(
+            backend.writes.isEmpty,
+            "no control keys means no writes at all; writes: \(backend.writes)"
+        )
+    }
+
     // MARK: - Below-minimum gating
 
     func testBelowMinimumIsClampedWithoutForce() throws {
@@ -521,6 +567,23 @@ private extension Capabilities {
             requiredKeys: ["CH0B", "CH0C"],
             enableWrites: [SMCKeyWrite(key: "CH0B", bytes: [0]), SMCKeyWrite(key: "CH0C", bytes: [0])],
             disableWrites: [SMCKeyWrite(key: "CH0B", bytes: [2]), SMCKeyWrite(key: "CH0C", bytes: [2])]
+        )
+        capabilities.batteryKeys = ["BUIC", "AC-W"]
+        return capabilities
+    }
+
+    /// macOS 27 / Apple Silicon shape: the charge-inhibit keys are refused by the
+    /// AppleSMC kernel driver, so capability detection leaves `chargingControl`
+    /// nil, but adapter power control is still writable.
+    static var oneFanAdapterOnly: Capabilities {
+        var capabilities = Capabilities.oneFan
+        capabilities.chargingControl = nil
+        capabilities.adapterControl = SMCControlKeyGroup(
+            identifier: "tahoe-adapter",
+            statusKey: "CHIE",
+            requiredKeys: ["CHIE"],
+            enableWrites: [SMCKeyWrite(key: "CHIE", bytes: [0x00])],
+            disableWrites: [SMCKeyWrite(key: "CHIE", bytes: [0x08])]
         )
         capabilities.batteryKeys = ["BUIC", "AC-W"]
         return capabilities


### PR DESCRIPTION
## Problem

On macOS 27 (Apple Silicon) charge limiting does not work at all. Every policy evaluation fails once per 10s period:

```
Battery policy evaluation failed: Charging control keys are not available on this Mac/system.
```

`smctl battery status` reports `charging control: unsupported`, and the configured limit is stored but never enforced.

## Root cause

The charge-inhibit keys are refused by the AppleSMC kernel driver with `kIOReturnNotPrivileged` for every userspace caller, root included. Measured on a MacBookPro18,2 (M1 Max), macOS 27.0 (26A5388g), probing all five AppleSMC user-client types with the repo's own `SMCParamStruct`:

| Key | Result |
|---|---|
| `CHLS` | `0xE00002C1` kIOReturnNotPrivileged (all client types, as root) |
| `CH0J` | `0xE00002C1` kIOReturnNotPrivileged (all client types, as root) |
| `CHTE` | absent |
| `CH0B` / `CH0C` | absent |
| `CHIE` | **present and writable** |

So `detectControlGroup` correctly leaves `chargingControl` nil — there is genuinely no usable charge-inhibit key on this OS.

Two things worth noting, since they rule out the obvious explanations:

- **Not a signing problem.** The same failure occurs with the official notarized Developer ID release, with a locally Developer ID signed build, and with an ad-hoc Homebrew build. Signature identity does not affect the kernel's per-key ACL.
- **Not a general loss of SMC write access.** Fan writes still succeed on the same machine (`smctl fan set 2200` moved both fans 1521 → 2216 RPM and back). Only the charge keys are blocked.

## Fix

Adapter power control (`CHIE`) is still writable and produces the same observable result: cutting adapter power stops the charge and lets the pack sail down to the lower bound.

- `applyChargingLocked` falls back to `applyAdapterLocked` when `chargingControl` is nil **and** `adapterControl` is available.
- `readChargingEnabledLocked` reports adapter state to match, so the reported charging state stays consistent with what actually gates charging.
- The status note now names the mechanism in use, since the adapter path means the Mac runs on battery while the limit holds — that is a real behavioural difference users should see.
- When neither mechanism exists, the original `unsupported` error is unchanged.

The fallback lives at the single choke point, so it also covers `setChargingEnabled`, the policy-driven `applyActionsLocked` path, and the shutdown restore.

## Verification

Hardware, MacBookPro18,2 / macOS 27.0:

```
maintain 60-70 @ 100%  → Now drawing from 'Battery Power'  (discharging)
maintain stop          → Now drawing from 'AC Power'
```

`smctl daemon status` now reports `last error: -` where it previously logged a failure every 10s.

Tests: full suite passes. Three cases added covering the new path — fallback cuts the adapter above the upper bound, restores it below the lower bound, and stays unsupported when neither mechanism is present.

## Note on scope

This changes behaviour on affected machines: holding the limit means running on battery while plugged in, rather than idling at the limit on adapter power. That is a meaningful trade-off, and I have surfaced it in the status note rather than making it silent. If you would prefer it behind an opt-in config key (e.g. `[battery] allow_adapter_fallback`) instead of automatic, I am happy to rework it — just say which you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)